### PR TITLE
feat: add GitHub plugin — credential, git proxy, GraphQL

### DIFF
--- a/fgap/plugins/__init__.py
+++ b/fgap/plugins/__init__.py
@@ -4,11 +4,13 @@ _registry: dict[str, type[Plugin]] = {}
 
 
 def register_plugin(plugin_cls: type[Plugin]) -> type[Plugin]:
-    """Register a plugin class. Can be used as a decorator."""
+    """Register a plugin class. Idempotent for the same class."""
     instance = plugin_cls()
     name = instance.name
     if name in _registry:
-        raise ValueError(f"Plugin '{name}' already registered")
+        if _registry[name] is plugin_cls:
+            return plugin_cls
+        raise ValueError(f"Plugin '{name}' already registered with a different class")
     _registry[name] = plugin_cls
     return plugin_cls
 

--- a/fgap/plugins/base.py
+++ b/fgap/plugins/base.py
@@ -30,8 +30,12 @@ class Plugin(ABC):
         """
         ...
 
-    def get_routes(self) -> list[tuple[str, str, callable]]:
-        """Return custom HTTP routes: [(method, path_pattern, handler), ...]."""
+    def get_routes(self, config: dict) -> list[tuple[str, str, callable]]:
+        """Return custom HTTP routes: [(method, path_pattern, handler), ...].
+
+        Args:
+            config: Plugin-specific config section.
+        """
         return []
 
     def get_commands(self) -> dict[str, callable]:

--- a/fgap/plugins/github/__init__.py
+++ b/fgap/plugins/github/__init__.py
@@ -1,0 +1,3 @@
+from fgap.plugins.github.plugin import GitHubPlugin
+
+__all__ = ["GitHubPlugin"]

--- a/fgap/plugins/github/credential.py
+++ b/fgap/plugins/github/credential.py
@@ -1,0 +1,39 @@
+import fnmatch
+
+
+def match_resource(pattern: str, resource: str) -> bool:
+    """Check if resource pattern matches (case-insensitive).
+
+    Patterns:
+    - "*" matches all resources
+    - "owner/*" matches all repos of that owner
+    - "owner/repo" matches exactly
+    - fnmatch patterns (e.g. "owner/repo-?") for advanced matching
+    """
+    p = pattern.lower()
+    r = resource.lower()
+    if p == "*":
+        return True
+    if p.endswith("/*"):
+        return r.split("/")[0] == p[:-2]
+    return fnmatch.fnmatch(r, p)
+
+
+def select_credential(resource: str, config: dict) -> dict | None:
+    """Select credential for a GitHub resource.
+
+    First-match-wins over the credentials array.
+
+    Returns:
+        {"env": {"GH_TOKEN": "...", "GH_HOST": "github.com"}} or None.
+    """
+    for cred in config.get("credentials", []):
+        for pattern in cred.get("resources", []):
+            if match_resource(pattern, resource):
+                return {
+                    "env": {
+                        "GH_TOKEN": cred["token"],
+                        "GH_HOST": "github.com",
+                    }
+                }
+    return None

--- a/fgap/plugins/github/git_proxy.py
+++ b/fgap/plugins/github/git_proxy.py
@@ -1,0 +1,75 @@
+import base64
+import logging
+
+import aiohttp
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+_FORWARDED_HEADERS = ("Content-Type", "Accept", "Content-Encoding")
+_RESPONSE_HEADERS = ("Content-Type", "Cache-Control")
+
+
+def make_routes(select_credential_fn, config):
+    """Create git smart HTTP proxy routes.
+
+    Returns list of (method, path, handler) tuples.
+    """
+    github_base = config.get("_github_base_url", "https://github.com")
+
+    async def handle_git(request: web.Request) -> web.Response:
+        owner = request.match_info["owner"]
+        repo = request.match_info["repo"]
+        path = request.match_info.get("path", "")
+        resource = f"{owner}/{repo}"
+
+        credential = select_credential_fn(resource, config)
+        if not credential:
+            raise web.HTTPForbidden(text=f"No credential for git on {resource}")
+
+        token = credential["env"]["GH_TOKEN"]
+        return await _proxy_to_github(
+            request, owner, repo, path, token, github_base,
+        )
+
+    return [
+        ("GET", "/git/{owner}/{repo}.git/{path:.*}", handle_git),
+        ("POST", "/git/{owner}/{repo}.git/{path:.*}", handle_git),
+    ]
+
+
+async def _proxy_to_github(request, owner, repo, path, token, github_base):
+    github_url = f"{github_base}/{owner}/{repo}.git/{path}"
+    if request.query_string:
+        github_url += f"?{request.query_string}"
+
+    credentials_b64 = base64.b64encode(
+        f"x-access-token:{token}".encode()
+    ).decode()
+
+    headers = {
+        "Authorization": f"Basic {credentials_b64}",
+        "User-Agent": "git/2.40.0",
+    }
+    for h in _FORWARDED_HEADERS:
+        if h in request.headers:
+            headers[h] = request.headers[h]
+
+    body = await request.read() if request.method == "POST" else None
+    timeout = aiohttp.ClientTimeout(total=60)
+
+    async with aiohttp.ClientSession() as session:
+        async with session.request(
+            request.method, github_url,
+            headers=headers, data=body, timeout=timeout,
+        ) as resp:
+            response_body = await resp.read()
+            response_headers = {}
+            for h in _RESPONSE_HEADERS:
+                if h in resp.headers:
+                    response_headers[h] = resp.headers[h]
+            return web.Response(
+                body=response_body,
+                status=resp.status,
+                headers=response_headers,
+            )

--- a/fgap/plugins/github/graphql.py
+++ b/fgap/plugins/github/graphql.py
@@ -1,0 +1,91 @@
+import aiohttp
+
+
+async def execute_graphql(
+    query: str,
+    variables: dict,
+    token: str,
+    extra_headers: dict | None = None,
+    *,
+    url: str | None = None,
+) -> dict:
+    """Execute a GraphQL query against the GitHub API.
+
+    Args:
+        query: GraphQL query or mutation string.
+        variables: Variables for the query.
+        token: Personal access token.
+        extra_headers: Additional headers (e.g. GraphQL-Features).
+        url: Override API URL (for testing).
+
+    Returns:
+        Response data dict.
+
+    Raises:
+        ValueError: If GraphQL returns errors.
+    """
+    url = url or "https://api.github.com/graphql"
+
+    headers = {
+        "Authorization": f"bearer {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "fgap",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+
+    body = {"query": query}
+    if variables:
+        body["variables"] = variables
+
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession() as session:
+        async with session.post(url, json=body, headers=headers, timeout=timeout) as resp:
+            result = await resp.json()
+            if "errors" in result:
+                raise ValueError(f"GraphQL error: {result['errors']}")
+            return result
+
+
+async def get_repository_id(
+    owner: str, repo: str, token: str, *, url: str | None = None,
+) -> str:
+    """Get repository node ID."""
+    query = """
+    query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+            id
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo}, token, url=url,
+    )
+    return result["data"]["repository"]["id"]
+
+
+async def get_issue_node_id(
+    owner: str, repo: str, issue_number: int, token: str,
+    *, url: str | None = None,
+) -> str:
+    """Get issue node ID."""
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+                id
+            }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query,
+        {"owner": owner, "repo": repo, "number": issue_number},
+        token,
+        extra_headers={"GraphQL-Features": "sub_issues"},
+        url=url,
+    )
+    issue = result.get("data", {}).get("repository", {}).get("issue")
+    if not issue:
+        raise ValueError(f"Issue #{issue_number} not found in {owner}/{repo}")
+    return issue["id"]

--- a/fgap/plugins/github/plugin.py
+++ b/fgap/plugins/github/plugin.py
@@ -1,0 +1,27 @@
+from fgap.plugins.base import Plugin
+
+
+class GitHubPlugin(Plugin):
+    """GitHub plugin: gh CLI execution and git smart HTTP proxy."""
+
+    @property
+    def name(self) -> str:
+        return "github"
+
+    @property
+    def tools(self) -> list[str]:
+        return ["gh"]
+
+    def select_credential(self, resource: str, config: dict) -> dict | None:
+        from .credential import select_credential
+
+        return select_credential(resource, config)
+
+    def get_routes(self, config: dict) -> list[tuple[str, str, callable]]:
+        from .git_proxy import make_routes
+
+        return make_routes(self.select_credential, config)
+
+    def get_commands(self) -> dict[str, callable]:
+        # Commands (discussion, issue, sub-issue) will be added later.
+        return {}

--- a/tests/test_github_credential.py
+++ b/tests/test_github_credential.py
@@ -1,0 +1,78 @@
+from fgap.plugins.github.credential import match_resource, select_credential
+
+
+class TestMatchResource:
+    def test_star_matches_all(self):
+        assert match_resource("*", "any/repo")
+
+    def test_owner_wildcard(self):
+        assert match_resource("acme/*", "acme/repo1")
+        assert match_resource("acme/*", "acme/anything")
+        assert not match_resource("acme/*", "other/repo")
+
+    def test_exact_match(self):
+        assert match_resource("acme/repo1", "acme/repo1")
+        assert not match_resource("acme/repo1", "acme/repo2")
+
+    def test_case_insensitive(self):
+        assert match_resource("Acme/*", "acme/repo")
+        assert match_resource("acme/Repo", "Acme/repo")
+
+    def test_fnmatch_single_char(self):
+        assert match_resource("acme/repo-?", "acme/repo-1")
+        assert not match_resource("acme/repo-?", "acme/repo-12")
+
+    def test_fnmatch_bracket(self):
+        assert match_resource("acme/repo-[abc]", "acme/repo-a")
+        assert not match_resource("acme/repo-[abc]", "acme/repo-d")
+
+
+class TestSelectCredential:
+    def test_first_match_wins(self):
+        config = {"credentials": [
+            {"token": "tok_specific", "resources": ["acme/repo1"]},
+            {"token": "tok_wildcard", "resources": ["acme/*"]},
+            {"token": "tok_default", "resources": ["*"]},
+        ]}
+        result = select_credential("acme/repo1", config)
+        assert result["env"]["GH_TOKEN"] == "tok_specific"
+
+    def test_wildcard_match(self):
+        config = {"credentials": [
+            {"token": "tok_specific", "resources": ["acme/repo1"]},
+            {"token": "tok_wildcard", "resources": ["acme/*"]},
+        ]}
+        result = select_credential("acme/repo2", config)
+        assert result["env"]["GH_TOKEN"] == "tok_wildcard"
+
+    def test_star_fallback(self):
+        config = {"credentials": [
+            {"token": "tok_default", "resources": ["*"]},
+        ]}
+        result = select_credential("any/repo", config)
+        assert result["env"]["GH_TOKEN"] == "tok_default"
+
+    def test_no_match_returns_none(self):
+        config = {"credentials": [
+            {"token": "tok", "resources": ["acme/*"]},
+        ]}
+        assert select_credential("other/repo", config) is None
+
+    def test_empty_credentials(self):
+        assert select_credential("any/repo", {"credentials": []}) is None
+
+    def test_no_credentials_key(self):
+        assert select_credential("any/repo", {}) is None
+
+    def test_includes_gh_host(self):
+        config = {"credentials": [{"token": "t", "resources": ["*"]}]}
+        result = select_credential("any/repo", config)
+        assert result["env"]["GH_HOST"] == "github.com"
+
+    def test_multiple_resources_per_credential(self):
+        config = {"credentials": [
+            {"token": "tok", "resources": ["acme/repo1", "acme/repo2"]},
+        ]}
+        assert select_credential("acme/repo1", config) is not None
+        assert select_credential("acme/repo2", config) is not None
+        assert select_credential("acme/repo3", config) is None

--- a/tests/test_github_git_proxy.py
+++ b/tests/test_github_git_proxy.py
@@ -1,0 +1,131 @@
+import base64
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from fgap.core.router import create_routes
+from fgap.plugins.github import GitHubPlugin
+
+
+@pytest.fixture
+async def mock_github_git_server():
+    """Mock GitHub git smart HTTP server."""
+    app = web.Application()
+    received = []
+
+    async def handle(request):
+        body = await request.read()
+        received.append({
+            "method": request.method,
+            "path": request.path,
+            "query": request.query_string,
+            "headers": dict(request.headers),
+            "body": body,
+        })
+
+        if "info/refs" in request.path:
+            return web.Response(
+                body=b"001e# service=git-upload-pack\n",
+                headers={"Content-Type": "application/x-git-upload-pack-advertisement"},
+            )
+        if "git-upload-pack" in request.path:
+            return web.Response(
+                body=b"PACK-DATA",
+                headers={"Content-Type": "application/x-git-upload-pack-result"},
+            )
+        if "git-receive-pack" in request.path:
+            return web.Response(
+                body=b"PUSH-OK",
+                headers={"Content-Type": "application/x-git-receive-pack-result"},
+            )
+        return web.Response(status=404)
+
+    app.router.add_route("*", "/{path:.*}", handle)
+
+    async with TestServer(app) as server:
+        yield server, received
+
+
+@pytest.fixture
+async def git_proxy_client(mock_github_git_server):
+    server, _ = mock_github_git_server
+    plugin = GitHubPlugin()
+    config = {
+        "plugins": {
+            "github": {
+                "credentials": [
+                    {"token": "test_pat_xxx", "resources": ["*"]},
+                ],
+                "_github_base_url": str(server.make_url("")),
+            }
+        }
+    }
+    app = create_routes(config, {"github": plugin})
+    async with TestClient(TestServer(app)) as client:
+        yield client
+
+
+class TestGitProxy:
+    async def test_info_refs_forwarded(self, git_proxy_client, mock_github_git_server):
+        _, received = mock_github_git_server
+        resp = await git_proxy_client.get(
+            "/git/owner/repo.git/info/refs?service=git-upload-pack",
+        )
+        assert resp.status == 200
+        body = await resp.read()
+        assert b"service=git-upload-pack" in body
+
+    async def test_auth_header_injected(self, git_proxy_client, mock_github_git_server):
+        _, received = mock_github_git_server
+        await git_proxy_client.get("/git/owner/repo.git/info/refs")
+        expected = base64.b64encode(b"x-access-token:test_pat_xxx").decode()
+        assert received[0]["headers"]["Authorization"] == f"Basic {expected}"
+
+    async def test_upload_pack_body_forwarded(self, git_proxy_client, mock_github_git_server):
+        _, received = mock_github_git_server
+        resp = await git_proxy_client.post(
+            "/git/owner/repo.git/git-upload-pack",
+            data=b"want-line",
+            headers={"Content-Type": "application/x-git-upload-pack-request"},
+        )
+        assert resp.status == 200
+        assert await resp.read() == b"PACK-DATA"
+        assert received[0]["body"] == b"want-line"
+        assert received[0]["headers"]["Content-Type"] == "application/x-git-upload-pack-request"
+
+    async def test_receive_pack(self, git_proxy_client):
+        resp = await git_proxy_client.post(
+            "/git/owner/repo.git/git-receive-pack",
+            data=b"push-data",
+            headers={"Content-Type": "application/x-git-receive-pack-request"},
+        )
+        assert resp.status == 200
+        assert await resp.read() == b"PUSH-OK"
+
+    async def test_query_string_forwarded(self, git_proxy_client, mock_github_git_server):
+        _, received = mock_github_git_server
+        await git_proxy_client.get(
+            "/git/owner/repo.git/info/refs?service=git-upload-pack",
+        )
+        assert received[0]["query"] == "service=git-upload-pack"
+
+    async def test_no_credential_returns_403(self):
+        plugin = GitHubPlugin()
+        config = {
+            "plugins": {
+                "github": {
+                    "credentials": [
+                        {"token": "t", "resources": ["specific/only"]},
+                    ],
+                }
+            }
+        }
+        app = create_routes(config, {"github": plugin})
+        async with TestClient(TestServer(app)) as client:
+            resp = await client.get("/git/other/repo.git/info/refs")
+            assert resp.status == 403
+
+    async def test_content_type_response_forwarded(self, git_proxy_client):
+        resp = await git_proxy_client.get("/git/owner/repo.git/info/refs")
+        assert resp.headers.get("Content-Type") == "application/x-git-upload-pack-advertisement"

--- a/tests/test_github_graphql.py
+++ b/tests/test_github_graphql.py
@@ -1,0 +1,114 @@
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+from fgap.plugins.github.graphql import (
+    execute_graphql,
+    get_issue_node_id,
+    get_repository_id,
+)
+
+
+@pytest.fixture
+async def mock_graphql_server():
+    """Mock GitHub GraphQL API."""
+    app = web.Application()
+    received = []
+
+    async def handle(request):
+        data = await request.json()
+        received.append({"data": data, "headers": dict(request.headers)})
+
+        query = data.get("query", "")
+        variables = data.get("variables", {})
+
+        if "error" in query:
+            return web.json_response({"errors": [{"message": "test error"}]})
+
+        if "issue" in query and "number" in str(variables):
+            if variables.get("number") == 999:
+                return web.json_response(
+                    {"data": {"repository": {"issue": None}}},
+                )
+            return web.json_response(
+                {"data": {"repository": {"issue": {"id": "I_abc"}}}},
+            )
+
+        if "repository" in query:
+            return web.json_response(
+                {"data": {"repository": {"id": "R_xyz"}}},
+            )
+
+        return web.json_response({"data": {"viewer": {"login": "testuser"}}})
+
+    app.router.add_post("/graphql", handle)
+
+    async with TestServer(app) as server:
+        yield server, received
+
+
+class TestExecuteGraphql:
+    async def test_successful_query(self, mock_graphql_server):
+        server, _ = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        result = await execute_graphql(
+            "query { viewer { login } }", {}, "tok", url=url,
+        )
+        assert result["data"]["viewer"]["login"] == "testuser"
+
+    async def test_auth_header_sent(self, mock_graphql_server):
+        server, received = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        await execute_graphql("query { viewer { login } }", {}, "secret", url=url)
+        assert received[0]["headers"]["Authorization"] == "bearer secret"
+
+    async def test_extra_headers_sent(self, mock_graphql_server):
+        server, received = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        await execute_graphql(
+            "query { viewer { login } }", {}, "tok",
+            extra_headers={"GraphQL-Features": "sub_issues"},
+            url=url,
+        )
+        assert received[0]["headers"]["GraphQL-Features"] == "sub_issues"
+
+    async def test_variables_sent(self, mock_graphql_server):
+        server, received = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        await execute_graphql(
+            "query($n: Int!) { f(n: $n) }", {"n": 42}, "tok", url=url,
+        )
+        assert received[0]["data"]["variables"] == {"n": 42}
+
+    async def test_graphql_error_raises(self, mock_graphql_server):
+        server, _ = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        with pytest.raises(ValueError, match="GraphQL error"):
+            await execute_graphql("query { error }", {}, "tok", url=url)
+
+
+class TestGetRepositoryId:
+    async def test_returns_id(self, mock_graphql_server):
+        server, _ = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        assert await get_repository_id("owner", "repo", "tok", url=url) == "R_xyz"
+
+
+class TestGetIssueNodeId:
+    async def test_returns_id(self, mock_graphql_server):
+        server, _ = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        result = await get_issue_node_id("owner", "repo", 1, "tok", url=url)
+        assert result == "I_abc"
+
+    async def test_not_found_raises(self, mock_graphql_server):
+        server, _ = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        with pytest.raises(ValueError, match="not found"):
+            await get_issue_node_id("owner", "repo", 999, "tok", url=url)
+
+    async def test_sends_sub_issues_header(self, mock_graphql_server):
+        server, received = mock_graphql_server
+        url = str(server.make_url("/graphql"))
+        await get_issue_node_id("owner", "repo", 1, "tok", url=url)
+        assert received[0]["headers"]["GraphQL-Features"] == "sub_issues"

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -52,10 +52,27 @@ class TestPluginRegistry:
         assert "dummy" in plugins
         assert "another" not in plugins
 
-    def test_duplicate_registration_raises(self):
+    def test_same_class_registration_is_idempotent(self):
         register_plugin(DummyPlugin)
+        register_plugin(DummyPlugin)  # should not raise
+
+    def test_name_conflict_with_different_class_raises(self):
+        register_plugin(DummyPlugin)
+
+        class ConflictPlugin(Plugin):
+            @property
+            def name(self):
+                return "dummy"
+
+            @property
+            def tools(self):
+                return ["conflict"]
+
+            def select_credential(self, resource, config):
+                return None
+
         with pytest.raises(ValueError, match="already registered"):
-            register_plugin(DummyPlugin)
+            register_plugin(ConflictPlugin)
 
     def test_discover_with_empty_config(self):
         register_plugin(DummyPlugin)


### PR DESCRIPTION
## Summary

- Add GitHub plugin with credential selection (resource pattern matching), git smart HTTP proxy, and async GraphQL utilities
- This is Step 3 partial — commands (discussion, issue, sub-issue) are deferred to a separate PR
- Plugin.get_routes() now accepts config dict; register_plugin() is idempotent for same class

## What's included

| Module | Lines | What it does |
|--------|-------|-------------|
| `credential.py` | ~40 | PAT selection: exact, `owner/*`, `*`, fnmatch, case-insensitive. First-match-wins |
| `git_proxy.py` | ~65 | Forwards git smart HTTP (info/refs, upload-pack, receive-pack) to GitHub with auth header injection |
| `graphql.py` | ~80 | Async GraphQL execution, repository ID lookup, issue node ID lookup |
| `plugin.py` | ~30 | GitHubPlugin class — wires credential, routes, commands together |

## What's NOT included (deferred)

- Custom commands: `discussion.py`, `issue.py`, `sub_issue.py` (~1,200 lines of migration from predecessor project)

## Test plan

- [x] Credential: exact/wildcard/star/fnmatch matching, case insensitivity, first-match-wins, multi-resource per credential, no-match returns None, GH_HOST included
- [x] Git proxy: info/refs forwarded, auth header injected (Basic base64), upload-pack body forwarded, receive-pack works, query string forwarded, no credential → 403, Content-Type response forwarded
- [x] GraphQL: successful query, auth header sent, extra headers sent, variables sent, GraphQL error raises ValueError, get_repository_id, get_issue_node_id (success + not found), sub_issues header sent
- [x] Plugin registry: idempotent registration, name conflict raises error
- [x] All 74 tests pass (43 existing + 31 new)

Tests use real aiohttp test servers as mock upstreams — no mocking libraries, real HTTP behavior verified.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)