### PR TITLE
feat: add discussion and sub-issue custom commands

### DIFF
--- a/fgap/plugins/github/commands/discussion.py
+++ b/fgap/plugins/github/commands/discussion.py
@@ -1,0 +1,543 @@
+"""Discussion command: GitHub Discussions via GraphQL API.
+
+gh CLI doesn't have native discussion support, so all subcommands
+are handled here (nothing falls through to subprocess).
+"""
+
+from ..graphql import execute_graphql, get_repository_id
+
+_GRAPHQL_URL = None
+
+
+async def execute(args: list[str], resource: str, credential: dict, *, url: str | None = None) -> dict:
+    """Execute discussion command. Always returns a result dict (never None)."""
+    url = url or _GRAPHQL_URL
+
+    if not args:
+        return _err("discussion subcommand required")
+
+    owner, repo = resource.split("/", 1)
+    token = credential["env"]["GH_TOKEN"]
+    subcmd = args[0]
+    rest = args[1:]
+
+    try:
+        if subcmd == "list":
+            return await _list_discussions(owner, repo, token, url)
+        elif subcmd == "view":
+            if not rest:
+                return _err("discussion number required")
+            return await _view_discussion(owner, repo, int(rest[0]), token, url)
+        elif subcmd == "create":
+            title, body, category = _parse_create_args(rest)
+            return await _create_discussion(owner, repo, title, body, category, token, url)
+        elif subcmd == "edit":
+            if not rest:
+                return _err("discussion number required")
+            title, body = _parse_edit_args(rest[1:])
+            return await _update_discussion(owner, repo, int(rest[0]), title, body, token, url)
+        elif subcmd == "close":
+            if not rest:
+                return _err("discussion number required")
+            return await _close_discussion(owner, repo, int(rest[0]), token, url)
+        elif subcmd == "reopen":
+            if not rest:
+                return _err("discussion number required")
+            return await _reopen_discussion(owner, repo, int(rest[0]), token, url)
+        elif subcmd == "delete":
+            if not rest:
+                return _err("discussion number required")
+            return await _delete_discussion(owner, repo, int(rest[0]), token, url)
+        elif subcmd == "comment":
+            return await _handle_comment(rest, owner, repo, token, url)
+        elif subcmd == "answer":
+            if not rest:
+                return _err("comment_id required")
+            return await _mark_answer(rest[0], token, url)
+        elif subcmd == "unanswer":
+            if not rest:
+                return _err("comment_id required")
+            return await _unmark_answer(rest[0], token, url)
+        elif subcmd == "poll":
+            return await _handle_poll(rest, token, url)
+        else:
+            return _err(f"Unknown discussion subcommand: {subcmd}")
+    except ValueError as e:
+        return _err(str(e))
+
+
+def _err(msg: str) -> dict:
+    return {"exit_code": 1, "stdout": "", "stderr": msg}
+
+
+# =============================================================================
+# Argument Parsing
+# =============================================================================
+
+
+def _parse_create_args(args: list[str]) -> tuple[str, str, str]:
+    """Parse --title, --body, --category from args."""
+    title = body = category = None
+    i = 0
+    while i < len(args):
+        if args[i] in ("--title", "-t") and i + 1 < len(args):
+            title = args[i + 1]
+            i += 2
+        elif args[i] in ("--body", "-b") and i + 1 < len(args):
+            body = args[i + 1]
+            i += 2
+        elif args[i] in ("--category", "-c") and i + 1 < len(args):
+            category = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    if not title:
+        raise ValueError("--title is required")
+    if not body:
+        raise ValueError("--body is required")
+    if not category:
+        raise ValueError("--category is required")
+    return title, body, category
+
+
+def _parse_edit_args(args: list[str]) -> tuple[str | None, str | None]:
+    """Parse --title, --body from args."""
+    title = body = None
+    i = 0
+    while i < len(args):
+        if args[i] in ("--title", "-t") and i + 1 < len(args):
+            title = args[i + 1]
+            i += 2
+        elif args[i] in ("--body", "-b") and i + 1 < len(args):
+            body = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    if not title and not body:
+        raise ValueError("--title or --body is required")
+    return title, body
+
+
+def _parse_comment_body(args: list[str]) -> str:
+    """Parse --body from args."""
+    i = 0
+    while i < len(args):
+        if args[i] in ("--body", "-b") and i + 1 < len(args):
+            return args[i + 1]
+        i += 1
+    raise ValueError("--body is required")
+
+
+def _parse_add_comment_args(args: list[str]) -> tuple[str, str | None]:
+    """Parse --body and --reply-to from args."""
+    body = reply_to = None
+    i = 0
+    while i < len(args):
+        if args[i] in ("--body", "-b") and i + 1 < len(args):
+            body = args[i + 1]
+            i += 2
+        elif args[i] == "--reply-to" and i + 1 < len(args):
+            reply_to = args[i + 1]
+            i += 2
+        else:
+            i += 1
+
+    if not body:
+        raise ValueError("--body is required")
+    return body, reply_to
+
+
+async def _handle_comment(
+    args: list[str], owner: str, repo: str, token: str, url: str | None,
+) -> dict:
+    if not args:
+        return _err("discussion number or 'edit'/'delete' required")
+
+    if args[0] == "delete":
+        if len(args) < 2:
+            return _err("comment_id required")
+        return await _delete_comment(args[1], token, url)
+
+    if args[0] == "edit":
+        if len(args) < 2:
+            return _err("comment_id required")
+        body = _parse_comment_body(args[2:])
+        return await _update_comment(args[1], body, token, url)
+
+    # Add comment: comment <number> --body "..."
+    number = int(args[0])
+    body, reply_to = _parse_add_comment_args(args[1:])
+    return await _add_comment(owner, repo, number, body, reply_to, token, url)
+
+
+async def _handle_poll(args: list[str], token: str, url: str | None) -> dict:
+    if not args:
+        return _err("poll subcommand required (vote)")
+
+    if args[0] == "vote":
+        if len(args) < 2:
+            return _err("option_id required")
+        return await _poll_vote(args[1], token, url)
+
+    return _err(f"Unknown poll subcommand: {args[0]}")
+
+
+# =============================================================================
+# GraphQL Helpers
+# =============================================================================
+
+
+async def _get_discussion_category_id(
+    owner: str, repo: str, category_name: str, token: str, url: str | None,
+) -> str:
+    query = """
+    query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+            discussionCategories(first: 100) {
+                nodes { id name slug }
+            }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo}, token, url=url,
+    )
+    categories = result["data"]["repository"]["discussionCategories"]["nodes"]
+    for cat in categories:
+        if cat["name"].lower() == category_name.lower() or cat["slug"].lower() == category_name.lower():
+            return cat["id"]
+    available = [c["name"] for c in categories]
+    raise ValueError(f"Category '{category_name}' not found. Available: {available}")
+
+
+async def _get_discussion_node_id(
+    owner: str, repo: str, number: int, token: str, url: str | None,
+) -> str:
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            discussion(number: $number) { id }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo, "number": number}, token, url=url,
+    )
+    discussion = result["data"]["repository"]["discussion"]
+    if not discussion:
+        raise ValueError(f"Discussion #{number} not found")
+    return discussion["id"]
+
+
+# =============================================================================
+# GraphQL Operations
+# =============================================================================
+
+
+async def _list_discussions(
+    owner: str, repo: str, token: str, url: str | None,
+) -> dict:
+    query = """
+    query($owner: String!, $repo: String!) {
+        repository(owner: $owner, name: $repo) {
+            discussions(first: 30, orderBy: {field: CREATED_AT, direction: DESC}) {
+                nodes {
+                    number
+                    title
+                    author { login }
+                    createdAt
+                    category { name }
+                    comments { totalCount }
+                }
+            }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo}, token, url=url,
+    )
+    discussions = result["data"]["repository"]["discussions"]["nodes"]
+
+    lines = []
+    for d in discussions:
+        author = d["author"]["login"] if d["author"] else "ghost"
+        comments = d["comments"]["totalCount"]
+        category = d["category"]["name"] if d["category"] else ""
+        lines.append(f"#{d['number']}\t{d['title']}\t{author}\t{category}\t{comments} comments")
+
+    return {"exit_code": 0, "stdout": "\n".join(lines), "stderr": ""}
+
+
+async def _view_discussion(
+    owner: str, repo: str, number: int, token: str, url: str | None,
+) -> dict:
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            discussion(number: $number) {
+                number
+                title
+                body
+                author { login }
+                createdAt
+                category { name }
+                url
+                comments(first: 50) {
+                    nodes {
+                        id
+                        author { login }
+                        body
+                        createdAt
+                    }
+                }
+            }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo, "number": number}, token, url=url,
+    )
+    d = result["data"]["repository"]["discussion"]
+    if not d:
+        raise ValueError(f"Discussion #{number} not found")
+
+    author = d["author"]["login"] if d["author"] else "ghost"
+    lines = [
+        f"title:\t{d['title']}",
+        f"number:\t{d['number']}",
+        f"author:\t{author}",
+        f"category:\t{d['category']['name'] if d['category'] else ''}",
+        f"url:\t{d['url']}",
+        f"created:\t{d['createdAt']}",
+        "",
+        "--- BODY ---",
+        d["body"] or "(empty)",
+        "",
+        "--- COMMENTS ---",
+    ]
+    for c in d["comments"]["nodes"]:
+        c_author = c["author"]["login"] if c["author"] else "ghost"
+        lines.append(f"\n[{c['id']}] {c_author} at {c['createdAt']}:")
+        lines.append(c["body"])
+
+    return {"exit_code": 0, "stdout": "\n".join(lines), "stderr": ""}
+
+
+async def _create_discussion(
+    owner: str, repo: str, title: str, body: str, category: str,
+    token: str, url: str | None,
+) -> dict:
+    repo_id = await get_repository_id(owner, repo, token, url=url)
+    category_id = await _get_discussion_category_id(owner, repo, category, token, url)
+
+    mutation = """
+    mutation($repositoryId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+        createDiscussion(input: {repositoryId: $repositoryId, categoryId: $categoryId, title: $title, body: $body}) {
+            discussion { number url }
+        }
+    }
+    """
+    result = await execute_graphql(mutation, {
+        "repositoryId": repo_id,
+        "categoryId": category_id,
+        "title": title,
+        "body": body,
+    }, token, url=url)
+    d = result["data"]["createDiscussion"]["discussion"]
+
+    return {"exit_code": 0, "stdout": d["url"], "stderr": f"Created discussion #{d['number']}"}
+
+
+async def _update_discussion(
+    owner: str, repo: str, number: int,
+    title: str | None, body: str | None,
+    token: str, url: str | None,
+) -> dict:
+    discussion_id = await _get_discussion_node_id(owner, repo, number, token, url)
+
+    mutation = """
+    mutation($discussionId: ID!, $title: String, $body: String) {
+        updateDiscussion(input: {discussionId: $discussionId, title: $title, body: $body}) {
+            discussion { number url }
+        }
+    }
+    """
+    result = await execute_graphql(mutation, {
+        "discussionId": discussion_id,
+        "title": title,
+        "body": body,
+    }, token, url=url)
+    d = result["data"]["updateDiscussion"]["discussion"]
+
+    return {"exit_code": 0, "stdout": d["url"], "stderr": f"Updated discussion #{d['number']}"}
+
+
+async def _close_discussion(
+    owner: str, repo: str, number: int, token: str, url: str | None,
+) -> dict:
+    discussion_id = await _get_discussion_node_id(owner, repo, number, token, url)
+
+    mutation = """
+    mutation($discussionId: ID!) {
+        closeDiscussion(input: {discussionId: $discussionId}) {
+            discussion { number url }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"discussionId": discussion_id}, token, url=url,
+    )
+    d = result["data"]["closeDiscussion"]["discussion"]
+
+    return {"exit_code": 0, "stdout": d["url"], "stderr": f"Closed discussion #{d['number']}"}
+
+
+async def _reopen_discussion(
+    owner: str, repo: str, number: int, token: str, url: str | None,
+) -> dict:
+    discussion_id = await _get_discussion_node_id(owner, repo, number, token, url)
+
+    mutation = """
+    mutation($discussionId: ID!) {
+        reopenDiscussion(input: {discussionId: $discussionId}) {
+            discussion { number url }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"discussionId": discussion_id}, token, url=url,
+    )
+    d = result["data"]["reopenDiscussion"]["discussion"]
+
+    return {"exit_code": 0, "stdout": d["url"], "stderr": f"Reopened discussion #{d['number']}"}
+
+
+async def _delete_discussion(
+    owner: str, repo: str, number: int, token: str, url: str | None,
+) -> dict:
+    discussion_id = await _get_discussion_node_id(owner, repo, number, token, url)
+
+    mutation = """
+    mutation($discussionId: ID!) {
+        deleteDiscussion(input: {id: $discussionId}) {
+            discussion { number }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"discussionId": discussion_id}, token, url=url,
+    )
+    d = result["data"]["deleteDiscussion"]["discussion"]
+
+    return {"exit_code": 0, "stdout": "", "stderr": f"Deleted discussion #{d['number']}"}
+
+
+async def _add_comment(
+    owner: str, repo: str, number: int, body: str, reply_to: str | None,
+    token: str, url: str | None,
+) -> dict:
+    discussion_id = await _get_discussion_node_id(owner, repo, number, token, url)
+
+    mutation = """
+    mutation($discussionId: ID!, $body: String!, $replyToId: ID) {
+        addDiscussionComment(input: {discussionId: $discussionId, body: $body, replyToId: $replyToId}) {
+            comment { id url }
+        }
+    }
+    """
+    result = await execute_graphql(mutation, {
+        "discussionId": discussion_id,
+        "body": body,
+        "replyToId": reply_to,
+    }, token, url=url)
+    c = result["data"]["addDiscussionComment"]["comment"]
+
+    return {"exit_code": 0, "stdout": c["url"], "stderr": f"Added comment {c['id']}"}
+
+
+async def _update_comment(
+    comment_id: str, body: str, token: str, url: str | None,
+) -> dict:
+    mutation = """
+    mutation($commentId: ID!, $body: String!) {
+        updateDiscussionComment(input: {commentId: $commentId, body: $body}) {
+            comment { id url }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"commentId": comment_id, "body": body}, token, url=url,
+    )
+    c = result["data"]["updateDiscussionComment"]["comment"]
+
+    return {"exit_code": 0, "stdout": c["url"], "stderr": f"Updated comment {c['id']}"}
+
+
+async def _delete_comment(comment_id: str, token: str, url: str | None) -> dict:
+    mutation = """
+    mutation($commentId: ID!) {
+        deleteDiscussionComment(input: {id: $commentId}) {
+            comment { id }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"commentId": comment_id}, token, url=url,
+    )
+    c = result["data"]["deleteDiscussionComment"]["comment"]
+
+    return {"exit_code": 0, "stdout": "", "stderr": f"Deleted comment {c['id']}"}
+
+
+async def _mark_answer(comment_id: str, token: str, url: str | None) -> dict:
+    mutation = """
+    mutation($commentId: ID!) {
+        markDiscussionCommentAsAnswer(input: {id: $commentId}) {
+            discussion { number url }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"commentId": comment_id}, token, url=url,
+    )
+    d = result["data"]["markDiscussionCommentAsAnswer"]["discussion"]
+
+    return {"exit_code": 0, "stdout": d["url"], "stderr": f"Marked as answer in discussion #{d['number']}"}
+
+
+async def _unmark_answer(comment_id: str, token: str, url: str | None) -> dict:
+    mutation = """
+    mutation($commentId: ID!) {
+        unmarkDiscussionCommentAsAnswer(input: {id: $commentId}) {
+            discussion { number url }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"commentId": comment_id}, token, url=url,
+    )
+    d = result["data"]["unmarkDiscussionCommentAsAnswer"]["discussion"]
+
+    return {"exit_code": 0, "stdout": d["url"], "stderr": f"Unmarked answer in discussion #{d['number']}"}
+
+
+async def _poll_vote(option_id: str, token: str, url: str | None) -> dict:
+    mutation = """
+    mutation($optionId: ID!) {
+        addDiscussionPollVote(input: {pollOptionId: $optionId}) {
+            pollOption { id option totalVoteCount }
+        }
+    }
+    """
+    result = await execute_graphql(
+        mutation, {"optionId": option_id}, token, url=url,
+    )
+    opt = result["data"]["addDiscussionPollVote"]["pollOption"]
+
+    return {
+        "exit_code": 0,
+        "stdout": f"Voted for: {opt['option']} (total: {opt['totalVoteCount']})",
+        "stderr": "",
+    }

--- a/fgap/plugins/github/commands/sub_issue.py
+++ b/fgap/plugins/github/commands/sub_issue.py
@@ -1,0 +1,225 @@
+"""Sub-issue command: GitHub Sub-Issues via GraphQL API.
+
+gh CLI doesn't have native sub-issue support, so all subcommands
+are handled here (nothing falls through to subprocess).
+"""
+
+from ..graphql import execute_graphql, get_issue_node_id
+
+_GRAPHQL_URL = None
+
+
+async def execute(args: list[str], resource: str, credential: dict, *, url: str | None = None) -> dict:
+    """Execute sub-issue command. Always returns a result dict (never None)."""
+    url = url or _GRAPHQL_URL
+
+    if not args:
+        return _err("sub-issue subcommand required")
+
+    owner, repo = resource.split("/", 1)
+    token = credential["env"]["GH_TOKEN"]
+    subcmd = args[0]
+    rest = args[1:]
+
+    try:
+        if subcmd == "list":
+            if not rest:
+                return _err("issue number required")
+            return await _list_sub_issues(owner, repo, int(rest[0]), token, url)
+        elif subcmd == "parent":
+            if not rest:
+                return _err("issue number required")
+            return await _get_parent(owner, repo, int(rest[0]), token, url)
+        elif subcmd == "add":
+            if len(rest) < 2:
+                return _err("parent and child issue numbers required")
+            return await _add_sub_issue(owner, repo, int(rest[0]), int(rest[1]), token, url)
+        elif subcmd == "remove":
+            if len(rest) < 2:
+                return _err("parent and child issue numbers required")
+            return await _remove_sub_issue(owner, repo, int(rest[0]), int(rest[1]), token, url)
+        elif subcmd == "reorder":
+            if len(rest) < 2:
+                return _err("parent and child issue numbers required")
+            before, after = _parse_reorder_args(rest[2:])
+            if not before and not after:
+                return _err("--before or --after required")
+            return await _reorder_sub_issue(
+                owner, repo, int(rest[0]), int(rest[1]), before, after, token, url,
+            )
+        else:
+            return _err(f"Unknown sub-issue subcommand: {subcmd}")
+    except ValueError as e:
+        return _err(str(e))
+
+
+def _err(msg: str) -> dict:
+    return {"exit_code": 1, "stdout": "", "stderr": msg}
+
+
+# =============================================================================
+# Argument Parsing
+# =============================================================================
+
+
+def _parse_reorder_args(args: list[str]) -> tuple[int | None, int | None]:
+    """Parse --before and --after from args."""
+    before = after = None
+    i = 0
+    while i < len(args):
+        if args[i] == "--before" and i + 1 < len(args):
+            before = int(args[i + 1])
+            i += 2
+        elif args[i] == "--after" and i + 1 < len(args):
+            after = int(args[i + 1])
+            i += 2
+        else:
+            i += 1
+    return before, after
+
+
+# =============================================================================
+# GraphQL Operations
+# =============================================================================
+
+
+_SUB_ISSUES_HEADER = {"GraphQL-Features": "sub_issues"}
+
+
+async def _list_sub_issues(
+    owner: str, repo: str, issue_number: int, token: str, url: str | None,
+) -> dict:
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+                subIssues(first: 50) {
+                    nodes { number title state }
+                }
+            }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo, "number": issue_number}, token,
+        extra_headers=_SUB_ISSUES_HEADER, url=url,
+    )
+    issue = result.get("data", {}).get("repository", {}).get("issue")
+    if not issue:
+        raise ValueError(f"Issue #{issue_number} not found in {owner}/{repo}")
+
+    nodes = issue.get("subIssues", {}).get("nodes", [])
+    lines = [f"{n['number']}\t{n['state']}\t{n['title']}" for n in nodes]
+    return {"exit_code": 0, "stdout": "\n".join(lines), "stderr": ""}
+
+
+async def _get_parent(
+    owner: str, repo: str, issue_number: int, token: str, url: str | None,
+) -> dict:
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+                parent { number title state }
+            }
+        }
+    }
+    """
+    result = await execute_graphql(
+        query, {"owner": owner, "repo": repo, "number": issue_number}, token,
+        extra_headers=_SUB_ISSUES_HEADER, url=url,
+    )
+    issue = result.get("data", {}).get("repository", {}).get("issue")
+    if not issue:
+        raise ValueError(f"Issue #{issue_number} not found in {owner}/{repo}")
+
+    parent = issue.get("parent")
+    if parent:
+        stdout = f"{parent['number']}\t{parent['state']}\t{parent['title']}"
+    else:
+        stdout = "No parent issue"
+    return {"exit_code": 0, "stdout": stdout, "stderr": ""}
+
+
+async def _add_sub_issue(
+    owner: str, repo: str, parent_number: int, child_number: int,
+    token: str, url: str | None,
+) -> dict:
+    issue_id = await get_issue_node_id(owner, repo, parent_number, token, url=url)
+    sub_issue_id = await get_issue_node_id(owner, repo, child_number, token, url=url)
+
+    mutation = """
+    mutation($issueId: ID!, $subIssueId: ID!) {
+        addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+            issue { number }
+            subIssue { number }
+        }
+    }
+    """
+    await execute_graphql(
+        mutation, {"issueId": issue_id, "subIssueId": sub_issue_id}, token,
+        extra_headers=_SUB_ISSUES_HEADER, url=url,
+    )
+    return {
+        "exit_code": 0,
+        "stdout": f"Added #{child_number} as sub-issue of #{parent_number}",
+        "stderr": "",
+    }
+
+
+async def _remove_sub_issue(
+    owner: str, repo: str, parent_number: int, child_number: int,
+    token: str, url: str | None,
+) -> dict:
+    issue_id = await get_issue_node_id(owner, repo, parent_number, token, url=url)
+    sub_issue_id = await get_issue_node_id(owner, repo, child_number, token, url=url)
+
+    mutation = """
+    mutation($issueId: ID!, $subIssueId: ID!) {
+        removeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+            issue { number }
+            subIssue { number }
+        }
+    }
+    """
+    await execute_graphql(
+        mutation, {"issueId": issue_id, "subIssueId": sub_issue_id}, token,
+        extra_headers=_SUB_ISSUES_HEADER, url=url,
+    )
+    return {
+        "exit_code": 0,
+        "stdout": f"Removed #{child_number} from #{parent_number}",
+        "stderr": "",
+    }
+
+
+async def _reorder_sub_issue(
+    owner: str, repo: str, parent_number: int, child_number: int,
+    before_number: int | None, after_number: int | None,
+    token: str, url: str | None,
+) -> dict:
+    issue_id = await get_issue_node_id(owner, repo, parent_number, token, url=url)
+    sub_issue_id = await get_issue_node_id(owner, repo, child_number, token, url=url)
+
+    before_id = None
+    after_id = None
+    if before_number:
+        before_id = await get_issue_node_id(owner, repo, before_number, token, url=url)
+    if after_number:
+        after_id = await get_issue_node_id(owner, repo, after_number, token, url=url)
+
+    mutation = """
+    mutation($issueId: ID!, $subIssueId: ID!, $beforeId: ID, $afterId: ID) {
+        reprioritizeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId, beforeId: $beforeId, afterId: $afterId}) {
+            issue { number }
+        }
+    }
+    """
+    await execute_graphql(mutation, {
+        "issueId": issue_id,
+        "subIssueId": sub_issue_id,
+        "beforeId": before_id,
+        "afterId": after_id,
+    }, token, extra_headers=_SUB_ISSUES_HEADER, url=url)
+
+    return {"exit_code": 0, "stdout": "Reordered", "stderr": ""}

--- a/fgap/plugins/github/plugin.py
+++ b/fgap/plugins/github/plugin.py
@@ -23,6 +23,12 @@ class GitHubPlugin(Plugin):
         return make_routes(self.select_credential, config)
 
     def get_commands(self) -> dict[str, callable]:
+        from .commands.discussion import execute as execute_discussion
         from .commands.issue import execute as execute_issue
+        from .commands.sub_issue import execute as execute_sub_issue
 
-        return {"issue": execute_issue}
+        return {
+            "issue": execute_issue,
+            "discussion": execute_discussion,
+            "sub-issue": execute_sub_issue,
+        }

--- a/tests/test_github_discussion_command.py
+++ b/tests/test_github_discussion_command.py
@@ -1,0 +1,435 @@
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from fgap.core.router import create_routes
+from fgap.plugins.github import GitHubPlugin
+from fgap.plugins.github.commands.discussion import (
+    _parse_add_comment_args,
+    _parse_comment_body,
+    _parse_create_args,
+    _parse_edit_args,
+    execute,
+)
+
+CRED = {"env": {"GH_TOKEN": "test-token"}}
+
+
+# =========================================================================
+# Pure logic tests
+# =========================================================================
+
+
+class TestParseCreateArgs:
+    def test_all_present(self):
+        t, b, c = _parse_create_args(["--title", "T", "--body", "B", "--category", "C"])
+        assert (t, b, c) == ("T", "B", "C")
+
+    def test_short_flags(self):
+        t, b, c = _parse_create_args(["-t", "T", "-b", "B", "-c", "C"])
+        assert (t, b, c) == ("T", "B", "C")
+
+    def test_missing_title(self):
+        with pytest.raises(ValueError, match="--title"):
+            _parse_create_args(["--body", "B", "--category", "C"])
+
+    def test_missing_body(self):
+        with pytest.raises(ValueError, match="--body"):
+            _parse_create_args(["--title", "T", "--category", "C"])
+
+    def test_missing_category(self):
+        with pytest.raises(ValueError, match="--category"):
+            _parse_create_args(["--title", "T", "--body", "B"])
+
+
+class TestParseEditArgs:
+    def test_title_only(self):
+        t, b = _parse_edit_args(["--title", "new title"])
+        assert t == "new title"
+        assert b is None
+
+    def test_body_only(self):
+        t, b = _parse_edit_args(["--body", "new body"])
+        assert t is None
+        assert b == "new body"
+
+    def test_both(self):
+        t, b = _parse_edit_args(["--title", "T", "--body", "B"])
+        assert (t, b) == ("T", "B")
+
+    def test_neither_raises(self):
+        with pytest.raises(ValueError, match="--title or --body"):
+            _parse_edit_args([])
+
+
+class TestParseCommentBody:
+    def test_basic(self):
+        assert _parse_comment_body(["--body", "hello"]) == "hello"
+
+    def test_short_flag(self):
+        assert _parse_comment_body(["-b", "hello"]) == "hello"
+
+    def test_missing(self):
+        with pytest.raises(ValueError, match="--body"):
+            _parse_comment_body([])
+
+
+class TestParseAddCommentArgs:
+    def test_body_only(self):
+        b, r = _parse_add_comment_args(["--body", "hello"])
+        assert b == "hello"
+        assert r is None
+
+    def test_with_reply_to(self):
+        b, r = _parse_add_comment_args(["--body", "hello", "--reply-to", "DC_123"])
+        assert b == "hello"
+        assert r == "DC_123"
+
+
+# =========================================================================
+# Execute routing tests
+# =========================================================================
+
+
+class TestExecuteRouting:
+    async def test_empty_args(self):
+        result = await execute([], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "subcommand required" in result["stderr"]
+
+    async def test_unknown_subcommand(self):
+        result = await execute(["nope"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "Unknown" in result["stderr"]
+
+    async def test_view_missing_number(self):
+        result = await execute(["view"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "number required" in result["stderr"]
+
+    async def test_close_missing_number(self):
+        result = await execute(["close"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+    async def test_edit_missing_number(self):
+        result = await execute(["edit"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+    async def test_comment_empty(self):
+        result = await execute(["comment"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+    async def test_answer_missing_id(self):
+        result = await execute(["answer"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+    async def test_poll_empty(self):
+        result = await execute(["poll"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+
+# =========================================================================
+# Handler tests with mock GraphQL server
+# =========================================================================
+
+
+@pytest.fixture
+async def mock_graphql():
+    """Mock GraphQL server that returns queued responses."""
+    app = web.Application()
+    state = {"responses": [], "requests": []}
+
+    async def handle(request):
+        data = await request.json()
+        state["requests"].append(data)
+        if not state["responses"]:
+            return web.json_response({"data": {}})
+        return web.json_response(state["responses"].pop(0))
+
+    app.router.add_post("/graphql", handle)
+    async with TestServer(app) as server:
+        yield server, state
+
+
+def _url(server) -> str:
+    return str(server.make_url("/graphql"))
+
+
+class TestListDiscussions:
+    async def test_returns_formatted_list(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussions": {"nodes": [
+            {
+                "number": 1, "title": "First",
+                "author": {"login": "alice"}, "createdAt": "2026-01-01",
+                "category": {"name": "General"}, "comments": {"totalCount": 3},
+            },
+            {
+                "number": 2, "title": "Second",
+                "author": None, "createdAt": "2026-01-02",
+                "category": None, "comments": {"totalCount": 0},
+            },
+        ]}}}})
+
+        result = await execute(["list"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "#1" in result["stdout"]
+        assert "alice" in result["stdout"]
+        assert "ghost" in result["stdout"]
+
+
+class TestViewDiscussion:
+    async def test_returns_details(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussion": {
+            "number": 5, "title": "My Discussion", "body": "The body",
+            "author": {"login": "bob"}, "createdAt": "2026-01-01",
+            "category": {"name": "Ideas"}, "url": "https://github.com/o/r/discussions/5",
+            "comments": {"nodes": [
+                {"id": "DC_1", "author": {"login": "carol"}, "body": "Nice!", "createdAt": "2026-01-02"},
+            ]},
+        }}}})
+
+        result = await execute(["view", "5"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "My Discussion" in result["stdout"]
+        assert "The body" in result["stdout"]
+        assert "carol" in result["stdout"]
+
+    async def test_not_found(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussion": None}}})
+
+        result = await execute(["view", "999"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 1
+        assert "not found" in result["stderr"]
+
+
+class TestCreateDiscussion:
+    async def test_creates_discussion(self, mock_graphql):
+        server, state = mock_graphql
+        # 1st call: get_repository_id
+        state["responses"].append({"data": {"repository": {"id": "R_123"}}})
+        # 2nd call: get_discussion_category_id
+        state["responses"].append({"data": {"repository": {"discussionCategories": {"nodes": [
+            {"id": "DC_1", "name": "General", "slug": "general"},
+            {"id": "DC_2", "name": "Ideas", "slug": "ideas"},
+        ]}}}})
+        # 3rd call: createDiscussion
+        state["responses"].append({"data": {"createDiscussion": {"discussion": {
+            "number": 10, "url": "https://github.com/o/r/discussions/10",
+        }}}})
+
+        result = await execute(
+            ["create", "--title", "New", "--body", "Content", "--category", "Ideas"],
+            "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert "discussions/10" in result["stdout"]
+
+        # Verify the mutation variables
+        create_req = state["requests"][2]
+        assert create_req["variables"]["repositoryId"] == "R_123"
+        assert create_req["variables"]["categoryId"] == "DC_2"
+
+    async def test_missing_args(self):
+        result = await execute(["create"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "--title" in result["stderr"]
+
+    async def test_category_not_found(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"id": "R_123"}}})
+        state["responses"].append({"data": {"repository": {"discussionCategories": {"nodes": [
+            {"id": "DC_1", "name": "General", "slug": "general"},
+        ]}}}})
+
+        result = await execute(
+            ["create", "--title", "T", "--body", "B", "--category", "NonExistent"],
+            "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 1
+        assert "not found" in result["stderr"].lower()
+
+
+class TestUpdateDiscussion:
+    async def test_updates(self, mock_graphql):
+        server, state = mock_graphql
+        # get_discussion_node_id
+        state["responses"].append({"data": {"repository": {"discussion": {"id": "D_1"}}}})
+        # updateDiscussion
+        state["responses"].append({"data": {"updateDiscussion": {"discussion": {
+            "number": 3, "url": "https://github.com/o/r/discussions/3",
+        }}}})
+
+        result = await execute(
+            ["edit", "3", "--title", "Updated"], "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert state["requests"][1]["variables"]["title"] == "Updated"
+
+
+class TestCloseDiscussion:
+    async def test_closes(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussion": {"id": "D_1"}}}})
+        state["responses"].append({"data": {"closeDiscussion": {"discussion": {
+            "number": 3, "url": "https://github.com/o/r/discussions/3",
+        }}}})
+
+        result = await execute(["close", "3"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Closed" in result["stderr"]
+
+
+class TestDeleteDiscussion:
+    async def test_deletes(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussion": {"id": "D_1"}}}})
+        state["responses"].append({"data": {"deleteDiscussion": {"discussion": {"number": 3}}}})
+
+        result = await execute(["delete", "3"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Deleted" in result["stderr"]
+
+
+class TestAddComment:
+    async def test_adds_comment(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussion": {"id": "D_1"}}}})
+        state["responses"].append({"data": {"addDiscussionComment": {"comment": {
+            "id": "DC_new", "url": "https://github.com/o/r/discussions/1#comment-new",
+        }}}})
+
+        result = await execute(
+            ["comment", "1", "--body", "Hello!"], "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert "comment-new" in result["stdout"]
+
+    async def test_with_reply_to(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussion": {"id": "D_1"}}}})
+        state["responses"].append({"data": {"addDiscussionComment": {"comment": {
+            "id": "DC_reply", "url": "https://github.com/o/r/discussions/1#reply",
+        }}}})
+
+        result = await execute(
+            ["comment", "1", "--body", "Reply", "--reply-to", "DC_parent"],
+            "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert state["requests"][1]["variables"]["replyToId"] == "DC_parent"
+
+
+class TestEditComment:
+    async def test_edits(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"updateDiscussionComment": {"comment": {
+            "id": "DC_1", "url": "https://github.com/o/r/discussions/1#comment-1",
+        }}}})
+
+        result = await execute(
+            ["comment", "edit", "DC_1", "--body", "Updated"],
+            "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert state["requests"][0]["variables"]["body"] == "Updated"
+
+
+class TestDeleteComment:
+    async def test_deletes(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"deleteDiscussionComment": {"comment": {"id": "DC_1"}}}})
+
+        result = await execute(
+            ["comment", "delete", "DC_1"], "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert "Deleted" in result["stderr"]
+
+
+class TestMarkAnswer:
+    async def test_marks(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"markDiscussionCommentAsAnswer": {"discussion": {
+            "number": 5, "url": "https://github.com/o/r/discussions/5",
+        }}}})
+
+        result = await execute(["answer", "DC_1"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Marked as answer" in result["stderr"]
+
+
+class TestUnmarkAnswer:
+    async def test_unmarks(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"unmarkDiscussionCommentAsAnswer": {"discussion": {
+            "number": 5, "url": "https://github.com/o/r/discussions/5",
+        }}}})
+
+        result = await execute(["unanswer", "DC_1"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Unmarked" in result["stderr"]
+
+
+class TestPollVote:
+    async def test_votes(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"addDiscussionPollVote": {"pollOption": {
+            "id": "PO_1", "option": "Yes", "totalVoteCount": 42,
+        }}}})
+
+        result = await execute(["poll", "vote", "PO_1"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Yes" in result["stdout"]
+        assert "42" in result["stdout"]
+
+    async def test_unknown_poll_subcommand(self):
+        result = await execute(["poll", "unknown"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "Unknown poll" in result["stderr"]
+
+
+# =========================================================================
+# Integration: via /cli endpoint
+# =========================================================================
+
+
+class TestDiscussionIntegration:
+    async def test_list_via_cli_endpoint(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"discussions": {"nodes": [
+            {
+                "number": 1, "title": "Test",
+                "author": {"login": "alice"}, "createdAt": "2026-01-01",
+                "category": {"name": "General"}, "comments": {"totalCount": 0},
+            },
+        ]}}}})
+
+        plugin = GitHubPlugin()
+        config = {
+            "plugins": {
+                "github": {
+                    "credentials": [{"token": "tok", "resources": ["*"]}],
+                }
+            }
+        }
+
+        import fgap.plugins.github.commands.discussion as disc_mod
+        original = disc_mod._GRAPHQL_URL
+        disc_mod._GRAPHQL_URL = _url(server)
+        try:
+            app = create_routes(config, {"github": plugin})
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/cli", json={
+                    "tool": "gh",
+                    "args": ["discussion", "list"],
+                    "resource": "owner/repo",
+                })
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["exit_code"] == 0
+                assert "#1" in data["stdout"]
+        finally:
+            disc_mod._GRAPHQL_URL = original

--- a/tests/test_github_sub_issue_command.py
+++ b/tests/test_github_sub_issue_command.py
@@ -1,0 +1,281 @@
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from fgap.core.router import create_routes
+from fgap.plugins.github import GitHubPlugin
+from fgap.plugins.github.commands.sub_issue import (
+    _parse_reorder_args,
+    execute,
+)
+
+CRED = {"env": {"GH_TOKEN": "test-token"}}
+
+
+# =========================================================================
+# Pure logic tests
+# =========================================================================
+
+
+class TestParseReorderArgs:
+    def test_before(self):
+        b, a = _parse_reorder_args(["--before", "5"])
+        assert b == 5
+        assert a is None
+
+    def test_after(self):
+        b, a = _parse_reorder_args(["--after", "10"])
+        assert b is None
+        assert a == 10
+
+    def test_both(self):
+        b, a = _parse_reorder_args(["--before", "5", "--after", "10"])
+        assert b == 5
+        assert a == 10
+
+    def test_empty(self):
+        b, a = _parse_reorder_args([])
+        assert b is None
+        assert a is None
+
+
+# =========================================================================
+# Execute routing tests
+# =========================================================================
+
+
+class TestExecuteRouting:
+    async def test_empty_args(self):
+        result = await execute([], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "subcommand required" in result["stderr"]
+
+    async def test_unknown_subcommand(self):
+        result = await execute(["nope"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "Unknown" in result["stderr"]
+
+    async def test_list_missing_number(self):
+        result = await execute(["list"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "number required" in result["stderr"]
+
+    async def test_parent_missing_number(self):
+        result = await execute(["parent"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+    async def test_add_missing_args(self):
+        result = await execute(["add", "1"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "parent and child" in result["stderr"]
+
+    async def test_remove_missing_args(self):
+        result = await execute(["remove"], "o/r", CRED)
+        assert result["exit_code"] == 1
+
+    async def test_reorder_missing_position(self):
+        result = await execute(["reorder", "1", "2"], "o/r", CRED)
+        assert result["exit_code"] == 1
+        assert "--before or --after" in result["stderr"]
+
+
+# =========================================================================
+# Handler tests with mock GraphQL server
+# =========================================================================
+
+
+@pytest.fixture
+async def mock_graphql():
+    """Mock GraphQL server that returns queued responses."""
+    app = web.Application()
+    state = {"responses": [], "requests": []}
+
+    async def handle(request):
+        data = await request.json()
+        state["requests"].append(data)
+        if not state["responses"]:
+            return web.json_response({"data": {}})
+        return web.json_response(state["responses"].pop(0))
+
+    app.router.add_post("/graphql", handle)
+    async with TestServer(app) as server:
+        yield server, state
+
+
+def _url(server) -> str:
+    return str(server.make_url("/graphql"))
+
+
+class TestListSubIssues:
+    async def test_returns_formatted_list(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {"subIssues": {"nodes": [
+            {"number": 10, "title": "Child A", "state": "OPEN"},
+            {"number": 11, "title": "Child B", "state": "CLOSED"},
+        ]}}}}})
+
+        result = await execute(["list", "5"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "10" in result["stdout"]
+        assert "Child A" in result["stdout"]
+        assert "CLOSED" in result["stdout"]
+
+    async def test_issue_not_found(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": None}}})
+
+        result = await execute(["list", "999"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 1
+        assert "not found" in result["stderr"]
+
+    async def test_empty_list(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {"subIssues": {"nodes": []}}}}})
+
+        result = await execute(["list", "1"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert result["stdout"] == ""
+
+
+class TestGetParent:
+    async def test_has_parent(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {
+            "parent": {"number": 1, "title": "Parent Issue", "state": "OPEN"},
+        }}}})
+
+        result = await execute(["parent", "5"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Parent Issue" in result["stdout"]
+
+    async def test_no_parent(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {"parent": None}}}})
+
+        result = await execute(["parent", "5"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "No parent" in result["stdout"]
+
+    async def test_issue_not_found(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": None}}})
+
+        result = await execute(["parent", "999"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 1
+        assert "not found" in result["stderr"]
+
+
+class TestAddSubIssue:
+    async def test_adds(self, mock_graphql):
+        server, state = mock_graphql
+        # get_issue_node_id for parent
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_parent"}}}})
+        # get_issue_node_id for child
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_child"}}}})
+        # addSubIssue mutation
+        state["responses"].append({"data": {"addSubIssue": {
+            "issue": {"number": 1}, "subIssue": {"number": 2},
+        }}})
+
+        result = await execute(["add", "1", "2"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "#2" in result["stdout"]
+        assert "#1" in result["stdout"]
+
+        # Verify mutation variables
+        mutation_req = state["requests"][2]
+        assert mutation_req["variables"]["issueId"] == "I_parent"
+        assert mutation_req["variables"]["subIssueId"] == "I_child"
+
+
+class TestRemoveSubIssue:
+    async def test_removes(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_parent"}}}})
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_child"}}}})
+        state["responses"].append({"data": {"removeSubIssue": {
+            "issue": {"number": 1}, "subIssue": {"number": 2},
+        }}})
+
+        result = await execute(["remove", "1", "2"], "owner/repo", CRED, url=_url(server))
+        assert result["exit_code"] == 0
+        assert "Removed" in result["stdout"]
+
+
+class TestReorderSubIssue:
+    async def test_reorder_with_before(self, mock_graphql):
+        server, state = mock_graphql
+        # parent
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_parent"}}}})
+        # child
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_child"}}}})
+        # before target
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_before"}}}})
+        # mutation
+        state["responses"].append({"data": {"reprioritizeSubIssue": {"issue": {"number": 1}}}})
+
+        result = await execute(
+            ["reorder", "1", "2", "--before", "3"], "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+        assert "Reordered" in result["stdout"]
+
+        mutation_req = state["requests"][3]
+        assert mutation_req["variables"]["beforeId"] == "I_before"
+        assert mutation_req["variables"]["afterId"] is None
+
+    async def test_reorder_with_after(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_parent"}}}})
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_child"}}}})
+        state["responses"].append({"data": {"repository": {"issue": {"id": "I_after"}}}})
+        state["responses"].append({"data": {"reprioritizeSubIssue": {"issue": {"number": 1}}}})
+
+        result = await execute(
+            ["reorder", "1", "2", "--after", "3"], "owner/repo", CRED, url=_url(server),
+        )
+        assert result["exit_code"] == 0
+
+        mutation_req = state["requests"][3]
+        assert mutation_req["variables"]["afterId"] == "I_after"
+        assert mutation_req["variables"]["beforeId"] is None
+
+
+# =========================================================================
+# Integration: via /cli endpoint
+# =========================================================================
+
+
+class TestSubIssueIntegration:
+    async def test_list_via_cli_endpoint(self, mock_graphql):
+        server, state = mock_graphql
+        state["responses"].append({"data": {"repository": {"issue": {"subIssues": {"nodes": [
+            {"number": 10, "title": "Child", "state": "OPEN"},
+        ]}}}}})
+
+        plugin = GitHubPlugin()
+        config = {
+            "plugins": {
+                "github": {
+                    "credentials": [{"token": "tok", "resources": ["*"]}],
+                }
+            }
+        }
+
+        import fgap.plugins.github.commands.sub_issue as si_mod
+        original = si_mod._GRAPHQL_URL
+        si_mod._GRAPHQL_URL = _url(server)
+        try:
+            app = create_routes(config, {"github": plugin})
+            async with TestClient(TestServer(app)) as client:
+                resp = await client.post("/cli", json={
+                    "tool": "gh",
+                    "args": ["sub-issue", "list", "5"],
+                    "resource": "owner/repo",
+                })
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["exit_code"] == 0
+                assert "Child" in data["stdout"]
+        finally:
+            si_mod._GRAPHQL_URL = original


### PR DESCRIPTION
## Summary

- Port **discussion** command (13 GraphQL operations) from fgp to fgap: list, view, create, edit, close, reopen, delete, comment add/edit/delete, answer/unanswer, poll vote
- Port **sub-issue** command (5 GraphQL operations) from fgp to fgap: list, parent, add, remove, reorder
- Register both commands in `GitHubPlugin.get_commands()`
- 62 tests added (161 total, all passing)

## Design decisions

- **No fallthrough**: Unlike `issue` (which falls through to `gh` CLI for commands it doesn't handle), `discussion` and `sub-issue` handle all subcommands because `gh` has no native support for these
- **`url` parameter injection for testability**: Each function accepts a `url` keyword arg to point at a mock GraphQL server. Cleaner than the `_API_URL` module-level monkey-patch used in the issue command. Integration tests still use `_GRAPHQL_URL` module variable for router-level testing
- **Async transformation**: All operations converted from sync (`urllib.request`) to async (`aiohttp` via `execute_graphql`)
- **Error handling**: `raise ValueError` replaced with `{"exit_code": 1, "stderr": "..."}` return values, consistent with fgap conventions

## Test plan

- [x] Pure logic: argument parsing for all parsers
- [x] Routing: all subcommands dispatched correctly, error cases for missing args
- [x] Handler tests: mock GraphQL server (aiohttp TestServer) verifying correct queries/mutations and response formatting
- [x] Integration: full router → plugin → command → mock API flow for both commands
- [x] All 161 tests pass

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)