### PR TITLE
feat: add Dockerfile, docker-compose, and healthcheck

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+*.egg-info
+__pycache__
+tests/
+.venv/
+*.pyc
+DESIGN.md
+CLAUDE.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml .
+COPY fgap/ fgap/
+COPY main.py .
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8766
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8766/health')"
+
+ENTRYPOINT ["python", "main.py"]
+CMD ["--config", "/etc/fgap/config.json5"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  fgap:
+    build: .
+    restart: unless-stopped
+    ports:
+      - "8766:8766"
+    volumes:
+      - ./config.json5:/etc/fgap/config.json5:ro


### PR DESCRIPTION
## Summary

- Add `Dockerfile`: Python 3.11-slim base with git, `HEALTHCHECK` hitting `/health` every 30s
- Add `docker-compose.yml`: `restart: unless-stopped`, config file as read-only volume
- Add `.dockerignore` for clean builds

CLI tools (`gh`, `gog`) are intentionally not included in the base image — deployment-specific (IQmin installs them via `user_data.sh`).

### Usage

```bash
# Build and run
docker compose up -d

# Check health
docker inspect --format='{{.State.Health.Status}}' fgap-fgap-1
```

## Test plan

- [x] 341 existing tests still pass
- [ ] `docker build` succeeds
- [ ] Container starts and `/health` returns 200

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)