### PR TITLE
fix: install gh and gog CLI tools in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,18 @@ FROM python:3.11-slim
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-RUN apt-get update && apt-get install -y --no-install-recommends git \
-    && rm -rf /var/lib/apt/lists/*
+ARG GH_VERSION=2.86.0
+ARG GOG_VERSION=0.11.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends git curl \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+       | tar xz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && mkdir /tmp/gogcli \
+    && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_amd64.tar.gz" \
+       | tar xz -C /tmp/gogcli \
+    && mv /tmp/gogcli/gog /usr/local/bin/gog \
+    && rm -rf /tmp/gh_* /tmp/gogcli /var/lib/apt/lists/*
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ docker compose up -d
 
 **Without Docker:**
 
+Requires [gh](https://cli.github.com/) and/or [gog](https://github.com/steipete/gogcli) installed on the host, depending on which plugins you use.
+
 ```bash
 uv pip install .
 python main.py --config config.json5


### PR DESCRIPTION
## Summary

- The proxy server executes `gh`/`gog` via `asyncio.create_subprocess_exec` but the Dockerfile didn't include these binaries — any `/cli` request would fail with "Command not found" inside the container
- Install gh v2.86.0 and gog v0.11.0 from GitHub Releases in the Dockerfile
- Add prerequisite note for the non-Docker setup path in README

## Test plan

- [ ] `docker build .` succeeds
- [ ] `docker run --rm <image> gh --version` prints gh 2.86.0
- [ ] `docker run --rm <image> gog --version` prints gog 0.11.0

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)