### PR TITLE
fix: support multi-architecture Docker builds (amd64/arm64)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@ FROM python:3.11-slim
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
+ARG TARGETARCH
 ARG GH_VERSION=2.86.0
 ARG GOG_VERSION=0.11.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends git curl \
-    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
        | tar xz -C /tmp \
-    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && mv /tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/local/bin/gh \
     && mkdir /tmp/gogcli \
-    && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_amd64.tar.gz" \
+    && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_${TARGETARCH}.tar.gz" \
        | tar xz -C /tmp/gogcli \
     && mv /tmp/gogcli/gog /usr/local/bin/gog \
     && rm -rf /tmp/gh_* /tmp/gogcli /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- The gh and gog binaries were hardcoded to `linux_amd64`, breaking builds on ARM64 hosts (e.g. AWS Graviton t4g instances)
- Use Docker's `TARGETARCH` build arg to download the correct architecture automatically

## Test plan

- [ ] `docker build .` succeeds on amd64
- [ ] `docker buildx build --platform linux/arm64 .` succeeds (or build on an ARM64 host)

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)