### PR TITLE
fix: inject -R flag when executing gh CLI subprocess

### DIFF
--- a/fgap/core/router.py
+++ b/fgap/core/router.py
@@ -83,7 +83,12 @@ def create_routes(config: dict, plugins: dict[str, Plugin]) -> web.Application:
                     return web.json_response(result)
 
             # Execute CLI subprocess
-            result = await execute_cli(tool, args, credential["env"], timeout=cli_timeout)
+            # gh needs -R to know the target repo (wrapper strips it for resource detection)
+            # api subcommand doesn't support -R — it uses endpoint paths instead
+            cli_args = args
+            if tool == "gh" and cmd != "api":
+                cli_args = args + ["-R", resource]
+            result = await execute_cli(tool, cli_args, credential["env"], timeout=cli_timeout)
             logger.info(
                 "cli tool=%s resource=%s cmd=%s exit_code=%d",
                 tool, resource, cmd, result["exit_code"],


### PR DESCRIPTION
## Summary

The wrapper strips `-R`/`--repo` from args for resource detection, but the proxy was not re-adding it when invoking `gh` via subprocess. This caused `not a git repository` errors in containerized environments with no local repo.

Adds `-R <resource>` to the args when executing `gh` subprocesses (except `api`, which uses endpoint paths instead). Mirrors fgp's `execute_gh_cli` approach.

## Test plan

- [ ] `gh issue list -R owner/repo` works from sandbox (no local git repo)
- [ ] `gh api repos/owner/repo/issues` still works (no `-R` injected)
- [ ] 341 existing tests pass

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)