### PR TITLE
fix: stop forwarding Content-Encoding header in git proxy

### DIFF
--- a/fgap/plugins/github/git_proxy.py
+++ b/fgap/plugins/github/git_proxy.py
@@ -8,7 +8,7 @@ from fgap.core.http import get_session
 
 logger = logging.getLogger(__name__)
 
-_FORWARDED_HEADERS = ("Content-Type", "Accept", "Content-Encoding")
+_FORWARDED_HEADERS = ("Content-Type", "Accept")
 _RESPONSE_HEADERS = ("Content-Type", "Cache-Control")
 
 


### PR DESCRIPTION
## Summary

- Remove `Content-Encoding` from the list of forwarded headers in the git smart HTTP proxy
- aiohttp server auto-decompresses gzip request bodies (`auto_decompress=True` by default), so `request.read()` returns plain bytes. Forwarding the original `Content-Encoding: gzip` header to GitHub caused a mismatch: GitHub expected gzip data but received uncompressed data, resulting in **400 Bad Request**
- This only manifested for repositories where the git client chose to gzip the `git-upload-pack` POST payload (determined by negotiation payload size). Smaller payloads were sent uncompressed and worked fine

## Test plan

- [ ] Restart fgap server
- [ ] `git fetch` on a repository that previously triggered the 400 (e.g. one with enough history/refs to trigger gzip negotiation)
- [ ] Verify `git push` works end-to-end

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)