### PR TITLE
fix: remove default request body size limit

### DIFF
--- a/fgap/core/router.py
+++ b/fgap/core/router.py
@@ -24,7 +24,7 @@ def create_routes(config: dict, plugins: dict[str, Plugin]) -> web.Application:
 
     Accepts plugins directly — use this in tests.
     """
-    app = web.Application()
+    app = web.Application(client_max_size=0)
 
     # Shared HTTP session lifecycle
     timeouts = config.get("timeouts", {})


### PR DESCRIPTION
## Summary

- aiohttp's default `client_max_size` (1 MiB) causes HTTP 413 errors when proxying large git push operations (e.g. force-pushing 600+ commits)
- Set `client_max_size=0` to disable the limit entirely
- fgap runs as a trusted local proxy and GitHub enforces its own limits, so proxy-side body size restriction is unnecessary

## Test plan

- [ ] Push a large git operation through the proxy (e.g. `git push --force-with-lease` with many commits)
- [ ] Verify normal git operations still work

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)