### PR TITLE
docs: add uv workflow rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,16 @@ Use the public-facing format for all commits, PRs, issues, and comments:
 ```
 
 Do NOT use internal formats that reference specific environments or real names.
+
+## Development
+
+This project uses **uv** for dependency management.
+
+**Do NOT use `uv pip install` or `pip install`.** Instead:
+
+```bash
+uv sync --extra dev   # Install all dependencies (including test tools)
+uv run pytest         # Run tests
+```
+
+If a command fails with "module not found", check `pyproject.toml` for the correct optional-dependency group and run `uv sync` — never install packages manually.


### PR DESCRIPTION
## Summary

- Add development section to CLAUDE.md with explicit `uv sync` / `uv run` workflow
- Prohibit `uv pip install` and `pip install` to prevent AI agents from bypassing uv dependency management

## Context

AI agents tend to fall back to `pip install` when a module is missing, instead of checking `pyproject.toml` and running `uv sync`. Explicit rules in CLAUDE.md should correct this behavior.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)