### PR TITLE
fix: stop treating -F as --body-file alias

### DIFF
--- a/fgap/client/gh.py
+++ b/fgap/client/gh.py
@@ -110,7 +110,12 @@ def strip_repo_flag(args: list[str]) -> list[str]:
 
 
 def transform_body_file(args: list[str]) -> list[str]:
-    """Convert ``--body-file``/``-F`` to ``--body`` with file contents."""
+    """Convert ``--body-file`` to ``--body`` with file contents.
+
+    Only handles ``--body-file`` (long form). ``-F`` is NOT ``--body-file``;
+    in upstream ``gh``, ``-F`` is short for ``--field`` (typed API parameter)
+    and must be passed through to the proxy-side ``gh`` for type inference.
+    """
     result = []
     skip_next = False
     for i, arg in enumerate(args):
@@ -119,13 +124,11 @@ def transform_body_file(args: list[str]) -> list[str]:
             continue
         next_arg = args[i + 1] if i + 1 < len(args) else None
 
-        if arg in ("--body-file", "-F") and next_arg is not None:
+        if arg == "--body-file" and next_arg is not None:
             result.extend(["--body", _read_file(next_arg)])
             skip_next = True
         elif arg.startswith("--body-file="):
             result.extend(["--body", _read_file(arg[len("--body-file="):])])
-        elif arg.startswith("-F") and len(arg) > 2:
-            result.extend(["--body", _read_file(arg[2:])])
         else:
             result.append(arg)
     return result


### PR DESCRIPTION
## Summary

`-F` in upstream `gh` is short for `--field` (typed API parameter with type inference), not `--body-file`. The previous code incorrectly treated `-F` as a `--body-file` alias, causing it to attempt file reads instead of passing through to the proxy-side `gh`.

## What changed

- Removed `-F` handling from `transform_body_file()` — only `--body-file` (long form) is now converted to `--body`
- `-F` / `-Fkey=value` now pass through to the proxy-side `gh`, which handles type inference (numbers, booleans, `@file`)

## What this fixes

- `gh api ... -F in_reply_to=123` errored with `File not found: in_reply_to=123` instead of sending integer `123` (#31)
- `gh pr comment ... -F -` errored with `File not found: -` instead of reading from stdin (#30)

## Tests

- Updated 2 existing tests: assert `-F` args pass through unchanged
- Added 1 new test: `-F -` (stdin) passes through

All 362 tests pass.

Closes #30
Closes #31

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)