### PR TITLE
fix(gh): handle --body-file - as stdin

### DIFF
--- a/fgap/client/gh.py
+++ b/fgap/client/gh.py
@@ -129,7 +129,10 @@ def transform_body_file(args: list[str], *, _stdin=None) -> list[str]:
         next_arg = args[i + 1] if i + 1 < len(args) else None
 
         if arg == "--body-file" and next_arg is not None:
-            result.extend(["--body", _read_file(next_arg)])
+            if next_arg == "-":
+                result.extend(["--body", _stdin.read()])
+            else:
+                result.extend(["--body", _read_file(next_arg)])
             skip_next = True
         elif arg.startswith("--body-file="):
             result.extend(["--body", _read_file(arg[len("--body-file="):])])

--- a/tests/test_client_gh.py
+++ b/tests/test_client_gh.py
@@ -126,6 +126,13 @@ class TestTransformBodyFile:
         result = transform_body_file(args, _stdin=fake_stdin)
         assert result == ["pr", "comment", "123", "--body", "hello from stdin"]
 
+    def test_body_file_stdin_reads_body(self):
+        """--body-file - reads stdin and converts to --body."""
+        args = ["pr", "create", "--body-file", "-"]
+        fake_stdin = io.StringIO("stdin content")
+        result = transform_body_file(args, _stdin=fake_stdin)
+        assert result == ["pr", "create", "--body", "stdin content"]
+
     def test_file_not_found(self):
         with pytest.raises(ValueError, match="File not found"):
             transform_body_file(["--body-file", "/nonexistent/file.md"])


### PR DESCRIPTION
## Summary

`--body-file -` should read from stdin (same as `-F -`), but `_read_file("-")` treated `-` as a literal file path and raised `ValueError: File not found: -`.

## Change

Check for `-` before calling `_read_file()` and read from stdin instead.

## Test

Added `test_body_file_stdin_reads_body` — verifies `--body-file -` reads from stdin and converts to `--body`.

## Scope

Partial fix for #32. Only covers the `--body-file -` pattern. Remaining patterns (`-F <path>`, `--input <path>`) are tracked in #32.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)
