### PR TITLE
fix(gh): treat -F as --body-file in non-api context

### DIFF
--- a/tests/test_client_gh.py
+++ b/tests/test_client_gh.py
@@ -133,6 +133,20 @@ class TestTransformBodyFile:
         result = transform_body_file(args, _stdin=fake_stdin)
         assert result == ["pr", "create", "--body", "stdin content"]
 
+    def test_dash_f_file_reads_body(self, tmp_path):
+        """-F <path> in non-api context reads file and converts to --body."""
+        f = tmp_path / "body.md"
+        f.write_text("file content")
+        result = transform_body_file(["issue", "create", "-F", str(f)])
+        assert result == ["issue", "create", "--body", "file content"]
+
+    def test_dash_f_file_in_api_passed_through(self, tmp_path):
+        """-F <path> in api context is --field, not --body-file."""
+        f = tmp_path / "body.md"
+        f.write_text("content")
+        args = ["api", "repos/o/r/issues", "-F", str(f)]
+        assert transform_body_file(args) == args
+
     def test_file_not_found(self):
         with pytest.raises(ValueError, match="File not found"):
             transform_body_file(["--body-file", "/nonexistent/file.md"])


### PR DESCRIPTION
## Summary

In gh CLI, `-F` means different things depending on the subcommand:
- `gh api`: `-F` is `--field` (key=value pairs) — passed through to proxy
- `gh issue/pr create/comment`: `-F` is `--body-file` — should read file client-side

Previously only `-F -` (stdin) was handled. `-F <path>` in non-api context was passed through to the host, where the file doesn't exist.

## Change

`transform_body_file()` now checks whether the subcommand is `api`. In non-api context, `-F <path>` reads the file client-side and converts to `--body`. In api context, `-F` is passed through as before.

## Tests

- `test_dash_f_file_reads_body` — `-F <path>` in `issue create` reads file
- `test_dash_f_file_in_api_passed_through` — `-F <path>` in `api` is passed through

## Scope

Partial fix for #32. Covers `-F <path>` in non-api context. Remaining: `--input <path>` for `gh api`.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)
