### PR TITLE
fix(gh): support --input <path> for gh api via stdin piping

### DIFF
--- a/fgap/client/base.py
+++ b/fgap/client/base.py
@@ -50,6 +50,7 @@ class ProxyClient:
 
     async def call_cli(
         self, tool: str, args: list[str], resource: str,
+        *, stdin_data: str | None = None,
     ) -> dict:
         """Send a CLI invocation to the proxy.
 
@@ -62,6 +63,8 @@ class ProxyClient:
         """
         url = f"{self.proxy_url}/cli"
         body = {"tool": tool, "args": args, "resource": resource}
+        if stdin_data is not None:
+            body["stdin_data"] = stdin_data
 
         session, should_close = await self._get_session()
         try:

--- a/fgap/core/executor.py
+++ b/fgap/core/executor.py
@@ -7,6 +7,7 @@ async def execute_cli(
     args: list[str],
     env_overrides: dict,
     timeout: int = 60,
+    stdin_data: str | None = None,
 ) -> dict:
     """Execute a CLI command as an async subprocess.
 
@@ -21,6 +22,7 @@ async def execute_cli(
     try:
         proc = await asyncio.create_subprocess_exec(
             binary, *args,
+            stdin=asyncio.subprocess.PIPE if stdin_data is not None else None,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
@@ -33,7 +35,8 @@ async def execute_cli(
         }
 
     try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        input_bytes = stdin_data.encode("utf-8") if stdin_data is not None else None
+        stdout, stderr = await asyncio.wait_for(proc.communicate(input=input_bytes), timeout=timeout)
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()

--- a/fgap/core/router.py
+++ b/fgap/core/router.py
@@ -47,6 +47,7 @@ def create_routes(config: dict, plugins: dict[str, Plugin]) -> web.Application:
         tool = data.get("tool", "")
         args = data.get("args", [])
         resource = data.get("resource", "")
+        stdin_data = data.get("stdin_data")
         cmd = args[0] if args else ""
 
         try:
@@ -88,7 +89,7 @@ def create_routes(config: dict, plugins: dict[str, Plugin]) -> web.Application:
             cli_args = args
             if tool == "gh" and cmd != "api":
                 cli_args = args + ["-R", resource]
-            result = await execute_cli(tool, cli_args, credential["env"], timeout=cli_timeout)
+            result = await execute_cli(tool, cli_args, credential["env"], timeout=cli_timeout, stdin_data=stdin_data)
             logger.info(
                 "cli tool=%s resource=%s cmd=%s exit_code=%d",
                 tool, resource, cmd, result["exit_code"],


### PR DESCRIPTION
## Summary

`gh api --input <path>` reads a file as the HTTP request body, but the file only exists on the client (sandbox). The server-side `gh` subprocess cannot access it.

## Change

Read the file client-side, convert `--input <path>` to `--input -`, and pipe the contents via a new `stdin_data` field in the wire protocol.

| File | Change |
|---|---|
| `fgap/client/gh.py` | Add `transform_api_input()` — reads file, converts to `--input -` |
| `fgap/client/base.py` | Accept `stdin_data` in `call_cli()`, include in wire protocol |
| `fgap/core/router.py` | Extract `stdin_data` from request, pass to `execute_cli()` |
| `fgap/core/executor.py` | Pipe `stdin_data` to subprocess stdin when present |

## Tests

6 new tests in `TestTransformApiInput`:
- `--input <path>` reads file and converts to `--input -`
- `--input=<path>` (equals form)
- `--input -` reads stdin
- No `--input` returns None
- Non-api context skipped
- File not found raises ValueError

372 tests passed.

## Scope

Closes #32. This is the final piece — together with #37 (`--body-file -`) and #38 (`-F <path>`), all three reported failure patterns are fixed.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)
