### PR TITLE
fix(gh-client): route stderr to stdout when stdout is empty on success

### DIFF
--- a/fgap/client/gh.py
+++ b/fgap/client/gh.py
@@ -385,10 +385,13 @@ async def run(
             print(result["stderr"], file=sys.stderr)
         return result["exit_code"]
 
-    if result["stderr"]:
-        print(result["stderr"], file=sys.stderr)
     if result["stdout"]:
         print(result["stdout"])
+    if result["stderr"]:
+        # gh writes status messages (e.g. "✓ Merged ...") to stderr.
+        # Print to stdout so callers that only capture stdout see them.
+        dest = sys.stdout if not result["stdout"] else sys.stderr
+        print(result["stderr"], file=dest)
 
     return 0
 

--- a/tests/test_client_gh.py
+++ b/tests/test_client_gh.py
@@ -452,17 +452,35 @@ class TestProxyCallAndOutput:
         assert code == 0
         assert "hello" in capsys.readouterr().out
 
-    async def test_stderr_printed(self, mock_proxy, capsys):
+    async def test_stderr_only_printed_to_stdout(self, mock_proxy, capsys):
+        """When stdout is empty, stderr goes to stdout so callers see it."""
         server, state = mock_proxy
         state["responses"].append(
-            web.json_response({"exit_code": 0, "stdout": "", "stderr": "info msg"}),
+            web.json_response({"exit_code": 0, "stdout": "", "stderr": "✓ Merged"}),
+        )
+        await run(
+            ["pr", "merge", "1", "-R", "o/r"],
+            _url(server),
+            _get_remote_url=_no_git(),
+        )
+        captured = capsys.readouterr()
+        assert "✓ Merged" in captured.out
+        assert captured.err == ""
+
+    async def test_stderr_with_stdout_stays_on_stderr(self, mock_proxy, capsys):
+        """When stdout has data, stderr stays on stderr."""
+        server, state = mock_proxy
+        state["responses"].append(
+            web.json_response({"exit_code": 0, "stdout": "data", "stderr": "info msg"}),
         )
         await run(
             ["issue", "list", "-R", "o/r"],
             _url(server),
             _get_remote_url=_no_git(),
         )
-        assert "info msg" in capsys.readouterr().err
+        captured = capsys.readouterr()
+        assert "data" in captured.out
+        assert "info msg" in captured.err
 
     async def test_nonzero_exit_code(self, mock_proxy, capsys):
         server, state = mock_proxy


### PR DESCRIPTION
## Summary

- `gh` writes status messages (e.g. `✓ Squash and merged ...`) to stderr, reserving stdout for data output
- When stdout is empty and exit code is 0, callers that only capture stdout see no output and may conclude the command had no effect
- Route stderr to stdout in this case so the status message is visible
- When stdout has data, stderr stays on stderr to avoid mixing data with status messages

## Test plan

- [x] Existing tests updated + new test added
- [x] `uv run pytest tests/test_client_gh.py` — 70 passed

Closes #40

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)