### PR TITLE
feat(google): add service account credential support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 ARG TARGETARCH
 ARG GH_VERSION=2.86.0
-ARG GOG_VERSION=0.11.0
+ARG GOG_VERSION=0.12.0-delight.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends git curl \
     && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
        | tar xz -C /tmp \
     && mv /tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/local/bin/gh \
     && mkdir /tmp/gogcli \
-    && curl -fsSL "https://github.com/steipete/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_${TARGETARCH}.tar.gz" \
+    && curl -fsSL "https://github.com/delight-co/gogcli/releases/download/v${GOG_VERSION}/gogcli_${GOG_VERSION}_linux_${TARGETARCH}.tar.gz" \
        | tar xz -C /tmp/gogcli \
     && mv /tmp/gogcli/gog /usr/local/bin/gog \
     && rm -rf /tmp/gh_* /tmp/gogcli /var/lib/apt/lists/*

--- a/config.example.json5
+++ b/config.example.json5
@@ -51,6 +51,7 @@
     // Google: gog CLI (Google Workspace)
     "google": {
       "credentials": [
+        // Option 1: OAuth (keyring-based)
         {
           // Password for gog's keyring (~/.config/gogcli/)
           "keyring_password": "your-keyring-password",
@@ -59,7 +60,15 @@
           // "account": "user@gmail.com",
 
           "resources": ["*"]
-        }
+        },
+
+        // Option 2: Service account (no OAuth needed, no token expiry)
+        // The SA can only access resources explicitly shared with its email.
+        // {
+        //   "sa_key_file": "/path/to/service-account-key.json",
+        //   "account": "my-sa@my-project.iam.gserviceaccount.com",
+        //   "resources": ["*"]
+        // }
       ]
     }
   }

--- a/fgap/plugins/google/credential.py
+++ b/fgap/plugins/google/credential.py
@@ -1,20 +1,52 @@
+import base64
+import logging
+import os
+import shutil
+
 from fgap.plugins.base import match_resource
+
+logger = logging.getLogger(__name__)
+
+_provisioned_sa_keys: set[str] = set()
+
+
+def _provision_sa_key(sa_key_file: str, account: str) -> None:
+    """Copy SA key to the path gog expects: ~/.config/gogcli/sa-{base64url(email)}.json"""
+    if account in _provisioned_sa_keys:
+        return
+    safe_email = base64.urlsafe_b64encode(
+        account.lower().strip().encode(),
+    ).decode().rstrip("=")
+    gog_config_dir = os.path.expanduser("~/.config/gogcli")
+    os.makedirs(gog_config_dir, exist_ok=True)
+    dest = os.path.join(gog_config_dir, f"sa-{safe_email}.json")
+    shutil.copy2(sa_key_file, dest)
+    os.chmod(dest, 0o600)
+    logger.info("provisioned SA key for %s -> %s", account, dest)
+    _provisioned_sa_keys.add(account)
 
 
 def select_credential(resource: str, config: dict) -> dict | None:
     """Select credential for a Google resource.
 
     First-match-wins over the credentials array.
+    Supports two credential types:
+    - OAuth (keyring_password): injects GOG_KEYRING_PASSWORD
+    - Service account (sa_key_file + account): provisions SA key and injects GOG_ACCOUNT
 
     Returns:
-        {"env": {"GOG_KEYRING_PASSWORD": "..."}} or None.
-        Includes GOG_ACCOUNT if the credential specifies an account.
+        {"env": {...}} or None.
     """
     for cred in config.get("credentials", []):
-        if "keyring_password" not in cred:
+        is_sa = "sa_key_file" in cred
+        is_oauth = "keyring_password" in cred
+        if not is_sa and not is_oauth:
             continue
         for pattern in cred.get("resources", []):
             if match_resource(pattern, resource):
+                if is_sa:
+                    _provision_sa_key(cred["sa_key_file"], cred["account"])
+                    return {"env": {"GOG_ACCOUNT": cred["account"]}}
                 env = {"GOG_KEYRING_PASSWORD": cred["keyring_password"]}
                 if "account" in cred:
                     env["GOG_ACCOUNT"] = cred["account"]

--- a/fgap/plugins/google/plugin.py
+++ b/fgap/plugins/google/plugin.py
@@ -22,32 +22,56 @@ class GooglePlugin(Plugin):
         return select_credential(resource, config)
 
     async def health_check(
-        self, config: dict, *, _run_gog=None,
+        self, config: dict, *, _run_gog=None, _check_sa=None,
     ) -> list[dict]:
         """Check gog credential validity.
 
-        For each credential, runs ``gog auth list`` to verify the
+        For OAuth credentials, runs ``gog auth list`` to verify the
         keyring is accessible and accounts are configured.
+        For SA credentials, checks that the key file exists and is readable.
         """
         _run_gog = _run_gog or _default_run_gog
+        _check_sa = _check_sa or _default_check_sa
         results = []
         for cred in config.get("credentials", []):
-            keyring_pw = cred.get("keyring_password", "")
-            entry = {
-                "masked_keyring_password": mask_value(keyring_pw, visible_prefix=4),
-                "resources": cred.get("resources", []),
-            }
-            try:
-                status = await _run_gog(keyring_pw)
-                if "accounts" in status:
-                    status["accounts"] = mask_emails_in_text(
-                        status["accounts"],
-                    )
-                entry.update(status)
-            except Exception as e:
-                entry.update({"valid": False, "error": str(e)})
-            results.append(entry)
+            if "sa_key_file" in cred:
+                entry = {
+                    "type": "service_account",
+                    "account": mask_emails_in_text(cred.get("account", "")),
+                    "resources": cred.get("resources", []),
+                }
+                try:
+                    status = _check_sa(cred["sa_key_file"])
+                    entry.update(status)
+                except Exception as e:
+                    entry.update({"valid": False, "error": str(e)})
+                results.append(entry)
+            else:
+                keyring_pw = cred.get("keyring_password", "")
+                entry = {
+                    "type": "oauth",
+                    "masked_keyring_password": mask_value(keyring_pw, visible_prefix=4),
+                    "resources": cred.get("resources", []),
+                }
+                try:
+                    status = await _run_gog(keyring_pw)
+                    if "accounts" in status:
+                        status["accounts"] = mask_emails_in_text(
+                            status["accounts"],
+                        )
+                    entry.update(status)
+                except Exception as e:
+                    entry.update({"valid": False, "error": str(e)})
+                results.append(entry)
         return results
+
+
+def _default_check_sa(sa_key_file: str) -> dict:
+    if not os.path.isfile(sa_key_file):
+        return {"valid": False, "error": f"SA key file not found: {sa_key_file}"}
+    if not os.access(sa_key_file, os.R_OK):
+        return {"valid": False, "error": f"SA key file not readable: {sa_key_file}"}
+    return {"valid": True}
 
 
 async def _default_run_gog(keyring_password: str) -> dict:

--- a/tests/test_google_credential.py
+++ b/tests/test_google_credential.py
@@ -1,4 +1,9 @@
-from fgap.plugins.google.credential import select_credential
+import os
+
+from fgap.plugins.google.credential import (
+    _provisioned_sa_keys,
+    select_credential,
+)
 
 
 class TestSelectCredential:
@@ -67,6 +72,85 @@ class TestSelectCredential:
     def test_skips_credential_without_keyring_password(self):
         config = {"credentials": [
             {"resources": ["*"]},
+            {"keyring_password": "pw", "resources": ["*"]},
+        ]}
+        result = select_credential("default", config)
+        assert result["env"]["GOG_KEYRING_PASSWORD"] == "pw"
+
+
+class TestSelectCredentialSA:
+    def test_sa_credential_returns_account(self, tmp_path):
+        _provisioned_sa_keys.clear()
+        sa_key = tmp_path / "sa.json"
+        sa_key.write_text('{"type":"service_account"}')
+        config = {"credentials": [
+            {
+                "sa_key_file": str(sa_key),
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["*"],
+            },
+        ]}
+        result = select_credential("default", config)
+        assert result["env"]["GOG_ACCOUNT"] == "sa@proj.iam.gserviceaccount.com"
+        assert "GOG_KEYRING_PASSWORD" not in result["env"]
+
+    def test_sa_provisions_key_to_gog_path(self, tmp_path, monkeypatch):
+        _provisioned_sa_keys.clear()
+        sa_key = tmp_path / "sa.json"
+        sa_key.write_text('{"type":"service_account","private_key":"xxx"}')
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config = {"credentials": [
+            {
+                "sa_key_file": str(sa_key),
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["*"],
+            },
+        ]}
+        select_credential("default", config)
+        # Check gog's expected path exists
+        import base64
+        encoded = base64.urlsafe_b64encode(
+            b"sa@proj.iam.gserviceaccount.com",
+        ).decode().rstrip("=")
+        expected = tmp_path / ".config" / "gogcli" / f"sa-{encoded}.json"
+        assert expected.exists()
+        assert expected.read_text() == sa_key.read_text()
+        assert oct(expected.stat().st_mode)[-3:] == "600"
+
+    def test_sa_preferred_over_oauth(self, tmp_path):
+        _provisioned_sa_keys.clear()
+        sa_key = tmp_path / "sa.json"
+        sa_key.write_text('{"type":"service_account"}')
+        config = {"credentials": [
+            {
+                "sa_key_file": str(sa_key),
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["*"],
+            },
+            {"keyring_password": "pw", "resources": ["*"]},
+        ]}
+        result = select_credential("default", config)
+        assert "GOG_ACCOUNT" in result["env"]
+        assert "GOG_KEYRING_PASSWORD" not in result["env"]
+
+    def test_sa_no_match_falls_through_to_oauth(self, tmp_path):
+        _provisioned_sa_keys.clear()
+        sa_key = tmp_path / "sa.json"
+        sa_key.write_text('{"type":"service_account"}')
+        config = {"credentials": [
+            {
+                "sa_key_file": str(sa_key),
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["specific@example.com"],
+            },
+            {"keyring_password": "pw", "resources": ["*"]},
+        ]}
+        result = select_credential("default", config)
+        assert result["env"]["GOG_KEYRING_PASSWORD"] == "pw"
+
+    def test_skips_credential_without_keyring_or_sa(self):
+        config = {"credentials": [
+            {"account": "user@example.com", "resources": ["*"]},
             {"keyring_password": "pw", "resources": ["*"]},
         ]}
         result = select_credential("default", config)

--- a/tests/test_google_health.py
+++ b/tests/test_google_health.py
@@ -98,3 +98,64 @@ class TestGoogleHealthCheck:
         r = results[0]
         assert r["valid"] is False
         assert "subprocess boom" in r["error"]
+
+
+class TestGoogleSAHealthCheck:
+    async def test_sa_valid(self, tmp_path):
+        sa_key = tmp_path / "sa.json"
+        sa_key.write_text('{"type":"service_account"}')
+
+        plugin = GooglePlugin()
+        config = {"credentials": [
+            {
+                "sa_key_file": str(sa_key),
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["*"],
+            },
+        ]}
+        results = await plugin.health_check(config)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r["type"] == "service_account"
+        assert r["valid"] is True
+        assert "***" in r["account"]
+        assert r["account"] != "sa@proj.iam.gserviceaccount.com"
+
+    async def test_sa_file_not_found(self):
+        plugin = GooglePlugin()
+        config = {"credentials": [
+            {
+                "sa_key_file": "/nonexistent/sa.json",
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["*"],
+            },
+        ]}
+        results = await plugin.health_check(config)
+
+        assert len(results) == 1
+        r = results[0]
+        assert r["valid"] is False
+        assert "not found" in r["error"]
+
+    async def test_mixed_oauth_and_sa(self, tmp_path):
+        sa_key = tmp_path / "sa.json"
+        sa_key.write_text('{"type":"service_account"}')
+
+        async def fake_run_gog(keyring_pw):
+            return {"valid": True, "accounts": "user@example.com"}
+
+        plugin = GooglePlugin()
+        config = {"credentials": [
+            {"keyring_password": "test-pw-12345", "resources": ["*"]},
+            {
+                "sa_key_file": str(sa_key),
+                "account": "sa@proj.iam.gserviceaccount.com",
+                "resources": ["*"],
+            },
+        ]}
+        results = await plugin.health_check(config, _run_gog=fake_run_gog)
+
+        assert len(results) == 2
+        assert results[0]["type"] == "oauth"
+        assert results[1]["type"] == "service_account"


### PR DESCRIPTION
## Summary

- Add service account (SA) key file support alongside existing OAuth keyring credentials
- When a credential entry specifies `sa_key_file` + `account`, fgap copies the key to gog's expected path (`~/.config/gogcli/sa-{base64url(email)}.json`) on first use (lazy provisioning)
- No keyring password or OAuth token needed — the SA accesses only resources explicitly shared with its email
- Update Dockerfile to use `delight-co/gogcli` fork `v0.12.0-delight.1` which adds SA pure mode support (upstream PR: https://github.com/steipete/gogcli/pull/399)
- Add config example for SA credential type

## Changes

| File | What |
|------|------|
| `fgap/plugins/google/credential.py` | SA credential selection + key provisioning to gog's expected path |
| `fgap/plugins/google/plugin.py` | Health check support for SA credentials (file existence check) |
| `config.example.json5` | SA credential config example |
| `Dockerfile` | Switch to `delight-co/gogcli` fork with SA pure mode |
| `tests/test_google_credential.py` | 5 new tests for SA credential selection + provisioning |
| `tests/test_google_health.py` | 3 new tests for SA health check |

## Design decisions

- **`sa_key_file` (path) over inline JSON**: Config stays clean (no JSON-in-JSON), secrets stay in files, key rotation = file swap
- **Lazy provisioning**: Copy SA key on first `select_credential` call. Plugin ABC has no startup hook, so sync file copy at selection time is the simplest approach
- **First-match-wins**: Same ordering semantics as OAuth credentials — SA and OAuth entries can coexist, first match wins

## Test plan

- [x] All existing tests pass (381 total)
- [x] New SA credential tests (5): selection, provisioning path, priority, fallthrough, skip invalid
- [x] New SA health check tests (3): valid file, missing file, mixed OAuth+SA

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)