### PR TITLE
refactor(google): remove SA key provisioning from fgap

### DIFF
--- a/fgap/plugins/google/credential.py
+++ b/fgap/plugins/google/credential.py
@@ -1,29 +1,4 @@
-import base64
-import logging
-import os
-import shutil
-
 from fgap.plugins.base import match_resource
-
-logger = logging.getLogger(__name__)
-
-_provisioned_sa_keys: set[str] = set()
-
-
-def _provision_sa_key(sa_key_file: str, account: str) -> None:
-    """Copy SA key to the path gog expects: ~/.config/gogcli/sa-{base64url(email)}.json"""
-    if account in _provisioned_sa_keys:
-        return
-    safe_email = base64.urlsafe_b64encode(
-        account.lower().strip().encode(),
-    ).decode().rstrip("=")
-    gog_config_dir = os.path.expanduser("~/.config/gogcli")
-    os.makedirs(gog_config_dir, exist_ok=True)
-    dest = os.path.join(gog_config_dir, f"sa-{safe_email}.json")
-    shutil.copy2(sa_key_file, dest)
-    os.chmod(dest, 0o600)
-    logger.info("provisioned SA key for %s -> %s", account, dest)
-    _provisioned_sa_keys.add(account)
 
 
 def select_credential(resource: str, config: dict) -> dict | None:
@@ -32,7 +7,11 @@ def select_credential(resource: str, config: dict) -> dict | None:
     First-match-wins over the credentials array.
     Supports two credential types:
     - OAuth (keyring_password): injects GOG_KEYRING_PASSWORD
-    - Service account (sa_key_file + account): provisions SA key and injects GOG_ACCOUNT
+    - Service account (sa_key_file + account): injects GOG_ACCOUNT
+
+    SA key must be pre-provisioned to gog's expected path
+    (~/.config/gogcli/sa-{base64url(email)}.json) by the infrastructure
+    layer (e.g. user_data.sh). fgap only injects the GOG_ACCOUNT env var.
 
     Returns:
         {"env": {...}} or None.
@@ -45,7 +24,6 @@ def select_credential(resource: str, config: dict) -> dict | None:
         for pattern in cred.get("resources", []):
             if match_resource(pattern, resource):
                 if is_sa:
-                    _provision_sa_key(cred["sa_key_file"], cred["account"])
                     return {"env": {"GOG_ACCOUNT": cred["account"]}}
                 env = {"GOG_KEYRING_PASSWORD": cred["keyring_password"]}
                 if "account" in cred:

--- a/tests/test_google_credential.py
+++ b/tests/test_google_credential.py
@@ -1,9 +1,4 @@
-import os
-
-from fgap.plugins.google.credential import (
-    _provisioned_sa_keys,
-    select_credential,
-)
+from fgap.plugins.google.credential import select_credential
 
 
 class TestSelectCredential:
@@ -79,13 +74,10 @@ class TestSelectCredential:
 
 
 class TestSelectCredentialSA:
-    def test_sa_credential_returns_account(self, tmp_path):
-        _provisioned_sa_keys.clear()
-        sa_key = tmp_path / "sa.json"
-        sa_key.write_text('{"type":"service_account"}')
+    def test_sa_credential_returns_account(self):
         config = {"credentials": [
             {
-                "sa_key_file": str(sa_key),
+                "sa_key_file": "/path/to/sa.json",
                 "account": "sa@proj.iam.gserviceaccount.com",
                 "resources": ["*"],
             },
@@ -94,36 +86,10 @@ class TestSelectCredentialSA:
         assert result["env"]["GOG_ACCOUNT"] == "sa@proj.iam.gserviceaccount.com"
         assert "GOG_KEYRING_PASSWORD" not in result["env"]
 
-    def test_sa_provisions_key_to_gog_path(self, tmp_path, monkeypatch):
-        _provisioned_sa_keys.clear()
-        sa_key = tmp_path / "sa.json"
-        sa_key.write_text('{"type":"service_account","private_key":"xxx"}')
-        monkeypatch.setenv("HOME", str(tmp_path))
+    def test_sa_preferred_over_oauth(self):
         config = {"credentials": [
             {
-                "sa_key_file": str(sa_key),
-                "account": "sa@proj.iam.gserviceaccount.com",
-                "resources": ["*"],
-            },
-        ]}
-        select_credential("default", config)
-        # Check gog's expected path exists
-        import base64
-        encoded = base64.urlsafe_b64encode(
-            b"sa@proj.iam.gserviceaccount.com",
-        ).decode().rstrip("=")
-        expected = tmp_path / ".config" / "gogcli" / f"sa-{encoded}.json"
-        assert expected.exists()
-        assert expected.read_text() == sa_key.read_text()
-        assert oct(expected.stat().st_mode)[-3:] == "600"
-
-    def test_sa_preferred_over_oauth(self, tmp_path):
-        _provisioned_sa_keys.clear()
-        sa_key = tmp_path / "sa.json"
-        sa_key.write_text('{"type":"service_account"}')
-        config = {"credentials": [
-            {
-                "sa_key_file": str(sa_key),
+                "sa_key_file": "/path/to/sa.json",
                 "account": "sa@proj.iam.gserviceaccount.com",
                 "resources": ["*"],
             },
@@ -133,13 +99,10 @@ class TestSelectCredentialSA:
         assert "GOG_ACCOUNT" in result["env"]
         assert "GOG_KEYRING_PASSWORD" not in result["env"]
 
-    def test_sa_no_match_falls_through_to_oauth(self, tmp_path):
-        _provisioned_sa_keys.clear()
-        sa_key = tmp_path / "sa.json"
-        sa_key.write_text('{"type":"service_account"}')
+    def test_sa_no_match_falls_through_to_oauth(self):
         config = {"credentials": [
             {
-                "sa_key_file": str(sa_key),
+                "sa_key_file": "/path/to/sa.json",
                 "account": "sa@proj.iam.gserviceaccount.com",
                 "resources": ["specific@example.com"],
             },


### PR DESCRIPTION
## Summary

- Remove `_provision_sa_key()` from credential.py — SA key placement to gog's expected path is now the infrastructure layer's responsibility, not fgap's
- fgap only injects `GOG_ACCOUNT` into the gog subprocess environment
- Fixes HTTP 500 errors when the gogcli config directory is mounted read-only in the fgap container

## Why

fgap's `_provision_sa_key()` copied the SA key JSON to `~/.config/gogcli/sa-{base64url(email)}.json` at request time. In production, `/root/.config/gogcli` is volume-mounted as `:ro` (for OAuth keyring data protection), causing the copy to fail with a write error → unhandled exception → HTTP 500.

Rather than loosening the mount to `:rw` or adding error handling around the copy, the provisioning responsibility is moved to the infrastructure layer (e.g. `user_data.sh`), which can place the SA key at gog's expected path before the container starts. This is cleaner: fgap doesn't need to know gog's internal key storage format, and the `:ro` mount stays intact.

## Changes

| File | What |
|------|------|
| `fgap/plugins/google/credential.py` | Remove `_provision_sa_key()`, `_provisioned_sa_keys`, and related imports. SA selection now just returns `{"env": {"GOG_ACCOUNT": ...}}` |
| `tests/test_google_credential.py` | Remove provisioning test, simplify SA tests (no tmp_path/monkeypatch needed) |

## Test plan

- [x] All existing tests pass
- [x] SA credential selection returns correct env vars
- [x] SA preferred over OAuth (first-match-wins)
- [x] SA no-match falls through to OAuth
- [x] Health check tests unaffected

✍️ Author: Claude Code (Reizan Container) with osabe