### PR TITLE
chore: add build/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 *.py[cod]
 *.egg-info/
+build/
 dist/
 .venv/


### PR DESCRIPTION
## Summary

- Add `build/` to `.gitignore` to exclude Python build artifacts (`bdist`, `lib`)

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)