### PR TITLE
chore: bump gog to v0.12.0-delight.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 ARG TARGETARCH
 ARG GH_VERSION=2.86.0
-ARG GOG_VERSION=0.12.0-delight.1
+ARG GOG_VERSION=0.12.0-delight.2
 
 RUN apt-get update && apt-get install -y --no-install-recommends git curl \
     && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \


### PR DESCRIPTION
## Summary

Bumps the bundled gog CLI from `v0.12.0-delight.1` to `v0.12.0-delight.2`.

New in this release:
- **fix(calendar)**: `getUserTimezone` falls back to UTC when no primary calendar exists, fixing 404 errors for all calendar commands in pure SA mode (delight-co/gogcli#2)

## Changes

- **`Dockerfile`** — `GOG_VERSION` ARG: `0.12.0-delight.1` → `0.12.0-delight.2`

## Test plan

- [x] Release assets verified: https://github.com/delight-co/gogcli/releases/tag/v0.12.0-delight.2
- [ ] Rebuild fgap image and verify calendar commands work in sandbox

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)