### PR TITLE
fix: resolve GraphQL node_id for comment edit --old/--new

### DIFF
--- a/fgap/plugins/github/commands/issue.py
+++ b/fgap/plugins/github/commands/issue.py
@@ -10,6 +10,7 @@ Everything else falls through to gh CLI (returns None).
 import aiohttp
 
 from fgap.core.http import get_session
+from fgap.plugins.github.graphql import get_comment_database_id
 
 _API_URL = "https://api.github.com"
 
@@ -172,6 +173,18 @@ async def _handle_comment_edit(
         return {"exit_code": 1, "stdout": "", "stderr": "comment ID required"}
 
     comment_id = positional[0]
+
+    # GraphQL node_ids (e.g. IC_kwDO...) are not valid in REST URL paths.
+    # Resolve to numeric databaseId first.
+    if not comment_id.isdigit():
+        try:
+            graphql_url = f"{api_url}/graphql" if api_url != _API_URL else None
+            comment_id = str(await get_comment_database_id(
+                comment_id, token, url=graphql_url,
+            ))
+        except ValueError as e:
+            return {"exit_code": 1, "stdout": "", "stderr": str(e)}
+
     url = f"{api_url}/repos/{owner}/{repo}/issues/comments/{comment_id}"
 
     try:

--- a/fgap/plugins/github/graphql.py
+++ b/fgap/plugins/github/graphql.py
@@ -75,6 +75,32 @@ async def get_repository_id(
     return result["data"]["repository"]["id"]
 
 
+async def get_comment_database_id(
+    node_id: str, token: str, *, url: str | None = None,
+) -> int:
+    """Resolve a GraphQL node_id (e.g. IC_kwDO...) to its REST API numeric id."""
+    query = """
+    query($id: ID!) {
+        node(id: $id) {
+            ... on IssueComment {
+                databaseId
+            }
+            ... on DiscussionComment {
+                databaseId
+            }
+            ... on PullRequestReviewComment {
+                databaseId
+            }
+        }
+    }
+    """
+    result = await execute_graphql(query, {"id": node_id}, token, url=url)
+    node = result.get("data", {}).get("node")
+    if not node or "databaseId" not in node:
+        raise ValueError(f"Could not resolve node_id {node_id} to a database ID")
+    return node["databaseId"]
+
+
 async def get_issue_node_id(
     owner: str, repo: str, issue_number: int, token: str,
     *, url: str | None = None,

--- a/tests/test_github_issue_command.py
+++ b/tests/test_github_issue_command.py
@@ -135,6 +135,28 @@ async def mock_github_api():
             return web.json_response(data)
         return web.Response(status=405)
 
+    async def handle_graphql(request):
+        body = await request.json()
+        query = body.get("query", "")
+        variables = body.get("variables", {})
+        state["requests"].append({
+            "method": "POST",
+            "path": request.path,
+        })
+        if "node(id:" in query or "node(id :" in query or "$id: ID!" in query:
+            node_id = variables.get("id", "")
+            mapping = state.get("node_id_map", {})
+            db_id = mapping.get(node_id)
+            if db_id is not None:
+                return web.json_response({
+                    "data": {"node": {"databaseId": db_id}},
+                })
+            return web.json_response({
+                "data": {"node": None},
+            })
+        return web.json_response({"data": {}})
+
+    app.router.add_route("POST", "/graphql", handle_graphql)
     app.router.add_route("*", "/repos/{owner}/{repo}/issues/comments/{comment_id}", handle_comment)
     app.router.add_route("*", "/repos/{owner}/{repo}/issues/{number}", handle_issue)
 
@@ -256,6 +278,31 @@ class TestHandleCommentEdit:
         )
         assert result["exit_code"] == 1
         assert "comment ID required" in result["stderr"]
+
+    async def test_node_id_resolved_to_numeric(self, mock_github_api):
+        server, state = mock_github_api
+        state["node_id_map"] = {"IC_kwDOtest123": 999}
+        state["comments"]["999"] = {"body": "fix typo plz"}
+        api_url = str(server.make_url(""))
+
+        result = await _handle_comment_edit(
+            ["IC_kwDOtest123", "--old", "plz", "--new", "please"],
+            "owner", "repo", "tok", api_url=api_url,
+        )
+        assert result["exit_code"] == 0
+        assert state["comments"]["999"]["body"] == "fix typo please"
+
+    async def test_node_id_not_found_returns_error(self, mock_github_api):
+        server, state = mock_github_api
+        state["node_id_map"] = {}
+        api_url = str(server.make_url(""))
+
+        result = await _handle_comment_edit(
+            ["IC_kwDOunknown", "--old", "x", "--new", "y"],
+            "owner", "repo", "tok", api_url=api_url,
+        )
+        assert result["exit_code"] == 1
+        assert "Could not resolve" in result["stderr"]
 
     async def test_rest_calls_correct_endpoints(self, mock_github_api):
         server, state = mock_github_api


### PR DESCRIPTION
## Summary

- `gh issue comment edit IC_kwDO... --old "..." --new "..."` was failing with `old string not found in body`
- Root cause: node_id was interpolated directly into REST API URL path, causing 404
- Fix: detect non-numeric comment IDs, resolve to `databaseId` via GraphQL `node()` query, then proceed with REST API
- `pr comment edit` also gets the fix for free (reuses `_handle_comment_edit`)

## Changes

- `graphql.py`: add `get_comment_database_id()` — resolves node_id to numeric ID via `node(id:) { ... on IssueComment { databaseId } }`
- `issue.py`: detect non-numeric `comment_id` and resolve before REST call
- `test_github_issue_command.py`: add mock GraphQL endpoint + 2 test cases (resolve success, resolve failure)

Closes #42

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)