### PR TITLE
feat: add langfuse plugin for CLI credential injection

### DIFF
--- a/config.example.json5
+++ b/config.example.json5
@@ -48,6 +48,19 @@
       ]
     },
 
+    // Langfuse: langfuse CLI (LLM tracing/prompts)
+    "langfuse": {
+      "credentials": [
+        {
+          "public_key": "pk-lf-YOUR_PUBLIC_KEY",
+          "secret_key": "sk-lf-YOUR_SECRET_KEY",
+          // Optional: override for self-hosted or US region
+          // "host": "https://us.cloud.langfuse.com",
+          "resources": ["*"]
+        }
+      ]
+    },
+
     // Notion: notion CLI (4ier/notion-cli)
     "notion": {
       "credentials": [

--- a/fgap/client/langfuse.py
+++ b/fgap/client/langfuse.py
@@ -1,0 +1,138 @@
+"""Langfuse CLI wrapper.
+
+Routes all langfuse commands through the fgap proxy for credential injection.
+
+Usage:
+    fgap-langfuse api traces list --limit 10
+    fgap-langfuse api prompts list
+    fgap-langfuse api sessions list
+"""
+
+import asyncio
+import os
+import sys
+
+from .base import ProxyClient
+
+
+MAIN_HELP = """\
+fgap-langfuse - finest-grained auth proxy for langfuse
+
+USAGE
+  fgap-langfuse <command> [args...]
+
+All arguments are forwarded to the langfuse CLI via the fgap proxy.
+Credentials are injected by the proxy — no local API keys needed.
+
+COMMANDS
+  api         Interact with Langfuse API resources
+  auth        Show authentication status
+
+EXAMPLES
+  fgap-langfuse api traces list --limit 10
+  fgap-langfuse api prompts list
+  fgap-langfuse api sessions list --limit 5
+  fgap-langfuse api __schema
+
+Run 'fgap-langfuse api <resource> --help' for more information.
+"""
+
+AUTH_HELP = """\
+Display authentication status for configured Langfuse credentials.
+
+USAGE
+  fgap-langfuse auth list
+"""
+
+
+async def run(args: list[str], proxy_url: str) -> int:
+    """Main wrapper logic. Returns exit code."""
+    if not args or args[0] in ("--help", "-h"):
+        print(MAIN_HELP, end="")
+        return 0
+
+    cmd = args[0]
+    rest = args[1:]
+
+    # Auth command: queries /auth/status instead of /cli
+    if cmd == "auth":
+        async with ProxyClient(proxy_url) as client:
+            return await _handle_auth(rest, client)
+
+    # Langfuse uses "default" as resource (single project per config)
+    resource = "default"
+
+    # Longer timeout: langfuse CLI can be slow on large trace lists
+    async with ProxyClient(proxy_url, timeout=120) as client:
+        try:
+            result = await client.call_cli("langfuse", args, resource)
+        except (ConnectionError, ValueError) as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+
+    if result["exit_code"] != 0:
+        if result["stderr"]:
+            print(result["stderr"], file=sys.stderr)
+        return result["exit_code"]
+
+    if result["stderr"]:
+        print(result["stderr"], file=sys.stderr)
+    if result["stdout"]:
+        print(result["stdout"])
+
+    return 0
+
+
+def _has_help_flag(args: list[str]) -> bool:
+    return any(a in ("--help", "-h") for a in args)
+
+
+async def _handle_auth(args: list[str], client: ProxyClient) -> int:
+    if not args or _has_help_flag(args):
+        print(AUTH_HELP, end="")
+        return 0
+
+    if args[0] != "list":
+        print(f"Error: Unknown auth command: {args[0]}", file=sys.stderr)
+        print("Run 'fgap-langfuse auth --help' for usage.", file=sys.stderr)
+        return 1
+
+    try:
+        data = await client.get_auth_status()
+    except (ConnectionError, ValueError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    creds = data.get("plugins", {}).get("langfuse", [])
+    if not creds:
+        print("No Langfuse credentials configured.")
+        return 0
+
+    for i, cred in enumerate(creds):
+        valid = cred.get("valid", False)
+        host = cred.get("host", "https://cloud.langfuse.com")
+        masked_pk = cred.get("masked_public_key", "***")
+        mark = "\u2713" if valid else "\u2717"
+        print(f"  {mark} [{i}] {masked_pk}")
+        if valid:
+            print(f"      Host: {host}")
+            project = cred.get("project", "")
+            if project:
+                print(f"      Project: {project}")
+        else:
+            print(f"      Error: {cred.get('error', 'Unknown error')}")
+        resources = cred.get("resources", [])
+        if resources:
+            print(f"      Resources: {', '.join(resources)}")
+
+    return 0
+
+
+def main():
+    """CLI entry point."""
+    proxy_url = os.environ.get("FGAP_PROXY_URL", "http://localhost:8766")
+    sys.exit(asyncio.run(run(sys.argv[1:], proxy_url)))
+
+
+if __name__ == "__main__":
+    main()

--- a/fgap/core/masking.py
+++ b/fgap/core/masking.py
@@ -12,6 +12,7 @@ SECRET_KEYS = frozenset({
     "client_secret",
     "refresh_token",
     "password",
+    "secret_key",
 })
 
 

--- a/fgap/core/router.py
+++ b/fgap/core/router.py
@@ -246,6 +246,12 @@ def create_app(config: dict) -> web.Application:
         pass
 
     try:
+        from fgap.plugins.langfuse import LangfusePlugin
+        register_plugin(LangfusePlugin)
+    except (ImportError, ValueError):
+        pass
+
+    try:
         from fgap.plugins.http_proxy import HttpProxyPlugin
         register_plugin(HttpProxyPlugin)
     except (ImportError, ValueError):

--- a/fgap/plugins/langfuse/__init__.py
+++ b/fgap/plugins/langfuse/__init__.py
@@ -1,0 +1,3 @@
+from fgap.plugins.langfuse.plugin import LangfusePlugin
+
+__all__ = ["LangfusePlugin"]

--- a/fgap/plugins/langfuse/credential.py
+++ b/fgap/plugins/langfuse/credential.py
@@ -1,0 +1,23 @@
+from fgap.plugins.base import match_resource
+
+
+def select_credential(resource: str, config: dict) -> dict | None:
+    """Select credential for a Langfuse resource.
+
+    First-match-wins over the credentials array.
+
+    Returns:
+        {"env": {"LANGFUSE_PUBLIC_KEY": "...", "LANGFUSE_SECRET_KEY": "...", ...}}
+        or None.
+    """
+    for cred in config.get("credentials", []):
+        for pattern in cred.get("resources", []):
+            if match_resource(pattern, resource):
+                env = {
+                    "LANGFUSE_PUBLIC_KEY": cred["public_key"],
+                    "LANGFUSE_SECRET_KEY": cred["secret_key"],
+                }
+                if "host" in cred:
+                    env["LANGFUSE_BASE_URL"] = cred["host"]
+                return {"env": env}
+    return None

--- a/fgap/plugins/langfuse/plugin.py
+++ b/fgap/plugins/langfuse/plugin.py
@@ -1,0 +1,79 @@
+import aiohttp
+
+from fgap.core.http import get_session
+from fgap.core.masking import mask_value
+from fgap.plugins.base import Plugin
+
+_DEFAULT_HOST = "https://cloud.langfuse.com"
+
+
+class LangfusePlugin(Plugin):
+    """Langfuse plugin: langfuse CLI execution with credential injection."""
+
+    @property
+    def name(self) -> str:
+        return "langfuse"
+
+    @property
+    def tools(self) -> list[str]:
+        return ["langfuse"]
+
+    def select_credential(self, resource: str, config: dict) -> dict | None:
+        from .credential import select_credential
+
+        return select_credential(resource, config)
+
+    async def health_check(
+        self, config: dict, *, _api_url: str | None = None,
+    ) -> list[dict]:
+        """Check credential validity via Langfuse REST API.
+
+        Calls GET /api/public/projects to verify the key pair.
+        """
+        results = []
+        for cred in config.get("credentials", []):
+            host = cred.get("host", _DEFAULT_HOST)
+            entry = {
+                "masked_public_key": mask_value(cred.get("public_key", "")),
+                "host": host,
+                "resources": cred.get("resources", []),
+            }
+            try:
+                api_url = _api_url or host
+                status = await _check_credentials(
+                    cred.get("public_key", ""),
+                    cred.get("secret_key", ""),
+                    api_url,
+                )
+                entry.update(status)
+            except Exception as e:
+                entry.update({"valid": False, "error": str(e)})
+            results.append(entry)
+        return results
+
+
+async def _check_credentials(
+    public_key: str, secret_key: str, api_url: str,
+) -> dict:
+    """Verify credentials via GET /api/public/projects with Basic Auth."""
+    auth = aiohttp.BasicAuth(public_key, secret_key)
+    health_timeout = aiohttp.ClientTimeout(total=10)
+    session = get_session()
+    own_session = session is None
+    if own_session:
+        session = aiohttp.ClientSession()
+    try:
+        async with session.get(
+            f"{api_url}/api/public/projects",
+            auth=auth,
+            timeout=health_timeout,
+        ) as resp:
+            if resp.status == 200:
+                data = await resp.json()
+                project_name = data.get("data", [{}])[0].get("name", "")
+                return {"valid": True, "project": project_name}
+            text = await resp.text()
+            return {"valid": False, "error": f"HTTP {resp.status}: {text}"}
+    finally:
+        if own_session:
+            await session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
 fgap-gh = "fgap.client.gh:main"
 fgap-gog = "fgap.client.gog:main"
 fgap-notion = "fgap.client.notion:main"
+fgap-langfuse = "fgap.client.langfuse:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/tests/test_langfuse_credential.py
+++ b/tests/test_langfuse_credential.py
@@ -1,0 +1,65 @@
+from fgap.plugins.langfuse.credential import select_credential
+
+
+class TestSelectCredential:
+    def test_wildcard_match(self):
+        config = {"credentials": [
+            {
+                "public_key": "pk-lf-test",
+                "secret_key": "sk-lf-test",
+                "host": "https://us.cloud.langfuse.com",
+                "resources": ["*"],
+            },
+        ]}
+        result = select_credential("default", config)
+        assert result == {"env": {
+            "LANGFUSE_PUBLIC_KEY": "pk-lf-test",
+            "LANGFUSE_SECRET_KEY": "sk-lf-test",
+            "LANGFUSE_BASE_URL": "https://us.cloud.langfuse.com",
+        }}
+
+    def test_host_optional(self):
+        config = {"credentials": [
+            {
+                "public_key": "pk-lf-test",
+                "secret_key": "sk-lf-test",
+                "resources": ["*"],
+            },
+        ]}
+        result = select_credential("default", config)
+        assert result == {"env": {
+            "LANGFUSE_PUBLIC_KEY": "pk-lf-test",
+            "LANGFUSE_SECRET_KEY": "sk-lf-test",
+        }}
+
+    def test_first_match_wins(self):
+        config = {"credentials": [
+            {
+                "public_key": "pk-first",
+                "secret_key": "sk-first",
+                "resources": ["project-a"],
+            },
+            {
+                "public_key": "pk-second",
+                "secret_key": "sk-second",
+                "resources": ["*"],
+            },
+        ]}
+        result = select_credential("project-a", config)
+        assert result["env"]["LANGFUSE_PUBLIC_KEY"] == "pk-first"
+
+    def test_no_match_returns_none(self):
+        config = {"credentials": [
+            {
+                "public_key": "pk-test",
+                "secret_key": "sk-test",
+                "resources": ["project-a"],
+            },
+        ]}
+        assert select_credential("project-b", config) is None
+
+    def test_empty_credentials(self):
+        assert select_credential("default", {"credentials": []}) is None
+
+    def test_no_credentials_key(self):
+        assert select_credential("default", {}) is None

--- a/tests/test_langfuse_health.py
+++ b/tests/test_langfuse_health.py
@@ -1,0 +1,153 @@
+from unittest.mock import AsyncMock, patch, MagicMock
+from aiohttp import ClientSession
+
+from fgap.plugins.langfuse.plugin import LangfusePlugin, _check_credentials
+
+
+class TestLangfuseHealthCheck:
+    async def test_valid_credentials(self):
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {
+                "public_key": "pk-lf-abc123test",
+                "secret_key": "sk-lf-secret456",
+                "host": "https://us.cloud.langfuse.com",
+                "resources": ["*"],
+            },
+        ]}
+
+        mock_status = {"valid": True, "project": "my-project"}
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            return_value=mock_status,
+        ):
+            results = await plugin.health_check(config)
+
+        assert len(results) == 1
+        assert results[0]["valid"] is True
+        assert results[0]["project"] == "my-project"
+        assert results[0]["host"] == "https://us.cloud.langfuse.com"
+        assert results[0]["resources"] == ["*"]
+
+    async def test_invalid_credentials(self):
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {
+                "public_key": "pk-lf-bad",
+                "secret_key": "sk-lf-bad",
+                "resources": ["*"],
+            },
+        ]}
+
+        mock_status = {"valid": False, "error": "HTTP 401: Unauthorized"}
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            return_value=mock_status,
+        ):
+            results = await plugin.health_check(config)
+
+        assert len(results) == 1
+        assert results[0]["valid"] is False
+        assert "401" in results[0]["error"]
+
+    async def test_connection_error(self):
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {
+                "public_key": "pk-lf-test1234",
+                "secret_key": "sk-lf-test1234",
+                "resources": ["*"],
+            },
+        ]}
+
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("refused"),
+        ):
+            results = await plugin.health_check(config)
+
+        assert len(results) == 1
+        assert results[0]["valid"] is False
+        assert "refused" in results[0]["error"]
+
+    async def test_host_defaults_when_absent(self):
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {"public_key": "pk", "secret_key": "sk", "resources": ["*"]},
+        ]}
+
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            return_value={"valid": True, "project": ""},
+        ):
+            results = await plugin.health_check(config)
+
+        assert results[0]["host"] == "https://cloud.langfuse.com"
+
+    async def test_masked_keys(self):
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {
+                "public_key": "pk-lf-abcdefghijk",
+                "secret_key": "sk-lf-secretkey123",
+                "resources": ["*"],
+            },
+        ]}
+
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            return_value={"valid": True, "project": "test"},
+        ):
+            results = await plugin.health_check(config)
+
+        assert "pk-lf-abcdefghijk" not in results[0]["masked_public_key"]
+        assert results[0]["masked_public_key"].startswith("pk-lf-ab")
+
+    async def test_empty_credentials(self):
+        plugin = LangfusePlugin()
+        results = await plugin.health_check({"credentials": []})
+        assert results == []
+
+    async def test_multiple_credentials(self):
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {"public_key": "pk1", "secret_key": "sk1", "resources": ["proj-a"]},
+            {"public_key": "pk2", "secret_key": "sk2", "host": "https://self-hosted.example.com", "resources": ["*"]},
+        ]}
+
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            return_value={"valid": True, "project": "test"},
+        ):
+            results = await plugin.health_check(config)
+
+        assert len(results) == 2
+        assert results[1]["host"] == "https://self-hosted.example.com"
+
+    async def test_api_url_override(self):
+        """The _api_url parameter overrides host for testing."""
+        plugin = LangfusePlugin()
+        config = {"credentials": [
+            {
+                "public_key": "pk-test",
+                "secret_key": "sk-test",
+                "host": "https://cloud.langfuse.com",
+                "resources": ["*"],
+            },
+        ]}
+
+        with patch(
+            "fgap.plugins.langfuse.plugin._check_credentials",
+            new_callable=AsyncMock,
+            return_value={"valid": True, "project": "test"},
+        ) as mock_check:
+            await plugin.health_check(config, _api_url="http://localhost:3000")
+            mock_check.assert_called_once_with(
+                "pk-test", "sk-test", "http://localhost:3000",
+            )


### PR DESCRIPTION
## Summary

Add a langfuse CLI plugin following the same pattern as the existing Notion plugin. The sandbox runs `fgap-langfuse` which routes commands through the fgap proxy for credential injection — no API keys in the sandbox environment.

- **plugins/langfuse**: credential selection + env var injection (`LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`)
- **client/langfuse.py**: thin wrapper (`fgap-langfuse`) for sandbox use
- **Health check**: verifies credentials via Langfuse REST API (`GET /api/public/projects` with Basic Auth), matching the Notion plugin's approach
- **masking.py**: add `secret_key` to `SECRET_KEYS` to prevent log leakage
- **config.example.json5**: add langfuse config section
- **router.py / pyproject.toml**: register plugin + entry point

### Config example

```json5
"langfuse": {
  "credentials": [
    {
      "public_key": "pk-lf-...",
      "secret_key": "sk-lf-...",
      "host": "https://us.cloud.langfuse.com",
      "resources": ["*"]
    }
  ]
}
```

### Flow

1. Sandbox runs `fgap-langfuse api traces list --limit 10`
2. Client POSTs to fgap proxy `/cli` endpoint
3. Proxy selects credential via langfuse plugin, injects env vars
4. Proxy executes host `langfuse` CLI as subprocess
5. Returns stdout/stderr/exit_code to sandbox

## Test plan

- [x] `test_langfuse_credential.py` — credential selection (wildcard, first-match, no-match, optional host)
- [x] `test_langfuse_health.py` — health check (valid/invalid/connection error, masking, api_url override)
- [x] All 522 existing tests pass

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)