### PR TITLE
feat: install langfuse CLI in fgap Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG GH_VERSION=2.86.0
 ARG GOG_VERSION=0.11.0-delight.4
 ARG NOTION_CLI_VERSION=0.3.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends git curl \
+RUN apt-get update && apt-get install -y --no-install-recommends git curl nodejs npm \
     && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${TARGETARCH}.tar.gz" \
        | tar xz -C /tmp \
     && mv /tmp/gh_${GH_VERSION}_linux_${TARGETARCH}/bin/gh /usr/local/bin/gh \
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git curl \
     && curl -fsSL "https://github.com/4ier/notion-cli/releases/download/v${NOTION_CLI_VERSION}/notion-cli_${NOTION_CLI_VERSION}_linux_${TARGETARCH}.tar.gz" \
        | tar xz -C /tmp \
     && mv /tmp/notion /usr/local/bin/notion \
+    && npm install -g langfuse-cli \
     && rm -rf /tmp/gh_* /tmp/gogcli /tmp/notion-cli* /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary

Add langfuse CLI (npm package) to the fgap Docker image. The langfuse plugin executes the CLI as a subprocess, so it needs to be installed in the container.

- Add `nodejs` and `npm` to apt packages
- `npm install -g langfuse-cli`

Without this, the langfuse plugin accepts requests but fails to execute the CLI.

## Test plan

- [ ] `docker build` succeeds
- [ ] `langfuse --version` works inside the container
- [ ] fgap proxy can execute `langfuse api traces list` via the plugin

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)